### PR TITLE
fix(be) : OAuth2 휴대폰번호 정규화 및 중복 검사 추가

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,6 +1,4 @@
 HELP.md
-SWAGGER_GUIDE.md
-OAUTH2_SETUP.md
 .gradle
 build/
 /docs

--- a/backend/src/main/java/com/oboe/backend/common/util/JwtUtil.java
+++ b/backend/src/main/java/com/oboe/backend/common/util/JwtUtil.java
@@ -167,7 +167,8 @@ public class JwtUtil {
   /**
    * 토큰에서 특정 클레임 추출
    */
-  private <T> T getClaimFromToken(String token, java.util.function.Function<Claims, T> claimsResolver) {
+  private <T> T getClaimFromToken(String token,
+      java.util.function.Function<Claims, T> claimsResolver) {
     Claims claims = getAllClaimsFromToken(token);
     return claimsResolver.apply(claims);
   }

--- a/backend/src/main/java/com/oboe/backend/common/util/PhoneNumberUtil.java
+++ b/backend/src/main/java/com/oboe/backend/common/util/PhoneNumberUtil.java
@@ -1,0 +1,144 @@
+package com.oboe.backend.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+/**
+ * 휴대폰번호 정규화 유틸리티 다양한 형식의 휴대폰번호를 표준 형식(01012345678)으로 변환
+ */
+@Slf4j
+@Component
+public class PhoneNumberUtil {
+
+  // 한국 휴대폰번호 패턴 (010만 지원)
+  private static final Pattern KOREAN_MOBILE_PATTERN = Pattern.compile("^010\\d{8}$");
+  // 네이버 형식: 010-1111-2222
+  private static final Pattern HYPHEN_PATTERN = Pattern.compile("^010-\\d{4}-\\d{4}$");
+
+  /**
+   * 휴대폰번호를 표준 형식(01012345678)으로 정규화
+   *
+   * @param phoneNumber 원본 휴대폰번호
+   * @return 정규화된 휴대폰번호 (01012345678 형식)
+   * @throws IllegalArgumentException 유효하지 않은 휴대폰번호인 경우
+   */
+  public static String normalizePhoneNumber(String phoneNumber) {
+    if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
+      log.warn("휴대폰번호가 null이거나 빈 문자열입니다.");
+      return null;
+    }
+
+    // 공백 제거
+    String normalized = phoneNumber.trim();
+    log.debug("원본 휴대폰번호: '{}'", phoneNumber);
+
+    // 이미 표준 형식인 경우
+    if (KOREAN_MOBILE_PATTERN.matcher(normalized).matches()) {
+      log.debug("이미 표준 형식입니다: {}", normalized);
+      return normalized;
+    }
+
+    // 국제번호 +82 형식 처리
+    if (normalized.startsWith("+82")) {
+      normalized = handleInternationalFormat(normalized);
+    }
+    // 하이픈이 포함된 형식 처리
+    else if (normalized.contains("-")) {
+      normalized = handleHyphenFormat(normalized);
+    }
+    // 공백이 포함된 형식 처리
+    else if (normalized.contains(" ")) {
+      normalized = handleSpaceFormat(normalized);
+    }
+
+    // 최종 검증
+    if (normalized != null && KOREAN_MOBILE_PATTERN.matcher(normalized).matches()) {
+      log.debug("정규화 성공: '{}' -> '{}'", phoneNumber, normalized);
+      return normalized;
+    }
+
+    log.warn("유효하지 않은 휴대폰번호 형식: '{}'", phoneNumber);
+    throw new IllegalArgumentException("유효하지 않은 휴대폰번호 형식입니다: " + phoneNumber);
+  }
+
+  /**
+   * 국제번호 +82 형식 처리 +82 10-3805-3128 -> 01038053128 +82-10-1234-5678 -> 01012345678
+   */
+  private static String handleInternationalFormat(String phoneNumber) {
+    log.debug("국제번호 형식 처리: {}", phoneNumber);
+
+    // +82 제거 (공백이나 하이픈이 있을 수 있음)
+    String withoutCountryCode = phoneNumber.substring(3).trim();
+
+    // +82- 형식인 경우 첫 번째 하이픈도 제거
+    if (withoutCountryCode.startsWith("-")) {
+      withoutCountryCode = withoutCountryCode.substring(1).trim();
+    }
+
+    // 0을 추가하여 010 형식으로 만들기
+    if (withoutCountryCode.startsWith("1")) {
+      withoutCountryCode = "0" + withoutCountryCode;
+    }
+
+    // 하이픈과 공백 제거
+    return withoutCountryCode.replaceAll("[\\s-]", "");
+  }
+
+  /**
+   * 하이픈이 포함된 형식 처리 010-3805-3128 -> 01038053128
+   */
+  private static String handleHyphenFormat(String phoneNumber) {
+    log.debug("하이픈 형식 처리: {}", phoneNumber);
+
+    if (HYPHEN_PATTERN.matcher(phoneNumber).matches()) {
+      return phoneNumber.replaceAll("-", "");
+    }
+
+    // 일반적인 하이픈 패턴 처리
+    return phoneNumber.replaceAll("-", "");
+  }
+
+  /**
+   * 공백이 포함된 형식 처리 010 3805 3128 -> 01038053128
+   */
+  private static String handleSpaceFormat(String phoneNumber) {
+    log.debug("공백 형식 처리: {}", phoneNumber);
+    return phoneNumber.replaceAll("\\s+", "");
+  }
+
+  /**
+   * 휴대폰번호 유효성 검증
+   *
+   * @param phoneNumber 검증할 휴대폰번호
+   * @return 유효한 휴대폰번호인지 여부
+   */
+  public static boolean isValidPhoneNumber(String phoneNumber) {
+    if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
+      return false;
+    }
+
+    try {
+      String normalized = normalizePhoneNumber(phoneNumber);
+      return normalized != null && KOREAN_MOBILE_PATTERN.matcher(normalized).matches();
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  /**
+   * 휴대폰번호를 안전하게 정규화 (예외 발생 시 null 반환)
+   *
+   * @param phoneNumber 원본 휴대폰번호
+   * @return 정규화된 휴대폰번호 또는 null
+   */
+  public static String safeNormalizePhoneNumber(String phoneNumber) {
+    try {
+      return normalizePhoneNumber(phoneNumber);
+    } catch (Exception e) {
+      log.warn("휴대폰번호 정규화 실패: {}", phoneNumber, e);
+      return null;
+    }
+  }
+}

--- a/backend/src/test/java/com/oboe/backend/common/util/PhoneNumberUtilTest.java
+++ b/backend/src/test/java/com/oboe/backend/common/util/PhoneNumberUtilTest.java
@@ -1,0 +1,119 @@
+package com.oboe.backend.common.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("휴대폰번호 정규화 유틸리티 테스트")
+class PhoneNumberUtilTest {
+
+  @Test
+  @DisplayName("OAuth2 휴대폰번호 정규화 테스트")
+  void testNormalizePhoneNumber_OAuth2() {
+    // 카카오 형식: +82 10-1111-2222
+    assertEquals("01011112222", PhoneNumberUtil.normalizePhoneNumber("+82 10-1111-2222"));
+
+    // 네이버 형식: 010-1111-2222
+    assertEquals("01011112222", PhoneNumberUtil.normalizePhoneNumber("010-1111-2222"));
+
+    // 표준 형식: 01011112222
+    assertEquals("01011112222", PhoneNumberUtil.normalizePhoneNumber("01011112222"));
+  }
+
+  @Test
+  @DisplayName("OAuth2 중복 검사 시나리오 테스트")
+  void testOAuth2DuplicateCheck() {
+    // 카카오와 네이버에서 같은 번호를 다른 형식으로 받아와도
+    // 같은 정규화된 번호로 변환되어 중복 검사가 정상 작동하는지 확인
+
+    String kakaoPhone = "+82 10-1111-2222";
+    String naverPhone = "010-1111-2222";
+
+    String normalizedKakao = PhoneNumberUtil.normalizePhoneNumber(kakaoPhone);
+    String normalizedNaver = PhoneNumberUtil.normalizePhoneNumber(naverPhone);
+
+    // 두 형식이 같은 정규화된 번호로 변환되는지 확인
+    assertEquals("01011112222", normalizedKakao);
+    assertEquals("01011112222", normalizedNaver);
+    assertEquals(normalizedKakao, normalizedNaver);
+  }
+
+  @Test
+  @DisplayName("010 번호만 지원하는지 테스트")
+  void testOnly010Numbers() {
+    // 010 번호는 정상 처리
+    assertEquals("01012345678", PhoneNumberUtil.normalizePhoneNumber("010-1234-5678"));
+    assertEquals("01012345678", PhoneNumberUtil.normalizePhoneNumber("+82 10-1234-5678"));
+
+    // 다른 통신사 번호는 예외 발생
+    assertThrows(IllegalArgumentException.class, () ->
+        PhoneNumberUtil.normalizePhoneNumber("016-1234-5678"));
+    assertThrows(IllegalArgumentException.class, () ->
+        PhoneNumberUtil.normalizePhoneNumber("017-1234-5678"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "01011112222",      // 표준 형식
+      "010-1111-2222",    // 네이버 형식
+      "+82 10-1111-2222"  // 카카오 형식
+  })
+  @DisplayName("OAuth2 유효한 휴대폰번호 형식 검증")
+  void testIsValidPhoneNumber_OAuth2Formats(String phoneNumber) {
+    assertTrue(PhoneNumberUtil.isValidPhoneNumber(phoneNumber),
+        "OAuth2 휴대폰번호가 유효해야 합니다: " + phoneNumber);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "010-123-456",     // 10자리 (너무 짧음)
+      "010-1234-56789",  // 12자리 (너무 김)
+      "016-1234-5678",   // 010이 아닌 번호
+      "017-1234-5678",   // 010이 아닌 번호
+      "abc-def-ghij",    // 문자 포함
+      "0101234567a",     // 문자 포함
+      "+1 123-456-7890", // 미국 번호
+      "+82 20-1234-5678" // 010이 아닌 국제번호
+  })
+  @DisplayName("유효하지 않은 휴대폰번호 형식 검증")
+  void testIsValidPhoneNumber_InvalidFormats(String phoneNumber) {
+    assertFalse(PhoneNumberUtil.isValidPhoneNumber(phoneNumber),
+        "휴대폰번호가 유효하지 않아야 합니다: " + phoneNumber);
+  }
+
+  @Test
+  @DisplayName("null 및 빈 문자열 처리")
+  void testNullAndEmpty() {
+    assertNull(PhoneNumberUtil.normalizePhoneNumber(null));
+    assertNull(PhoneNumberUtil.normalizePhoneNumber(""));
+    assertNull(PhoneNumberUtil.normalizePhoneNumber("   "));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 형식에 대한 예외 처리")
+  void testInvalidFormatThrowsException() {
+    assertThrows(IllegalArgumentException.class, () ->
+        PhoneNumberUtil.normalizePhoneNumber("010-123-456"));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        PhoneNumberUtil.normalizePhoneNumber("020-1234-5678"));
+
+    assertThrows(IllegalArgumentException.class, () ->
+        PhoneNumberUtil.normalizePhoneNumber("abc-def-ghij"));
+  }
+
+  @Test
+  @DisplayName("안전한 정규화 테스트")
+  void testSafeNormalizePhoneNumber() {
+    // 유효한 번호
+    assertEquals("01012345678", PhoneNumberUtil.safeNormalizePhoneNumber("010-1234-5678"));
+
+    // 유효하지 않은 번호 (null 반환)
+    assertNull(PhoneNumberUtil.safeNormalizePhoneNumber("010-123-456"));
+    assertNull(PhoneNumberUtil.safeNormalizePhoneNumber("invalid"));
+    assertNull(PhoneNumberUtil.safeNormalizePhoneNumber(null));
+  }
+}


### PR DESCRIPTION
※ 카카오(+82 10-1111-2222)와 네이버(010-1111-2222)로 받아와서 01011112222와 같은 번호지만 중복으로 가입할 수 있는  제약 조건 위반
1. PhoneNumberUtil 로 휴대폰번호 정규화 (01012345678 형식)
2. OAuth2 회원가입 시 정규화된 휴대폰번호로 중복 검사
4. OAuth2 PhoneNumberUtil 테스트 코드 추가"