### PR TITLE
feat(be) :  장바구니(Cart) API 개발

### DIFF
--- a/backend/src/main/generated/com/oboe/backend/cart/entity/QCart.java
+++ b/backend/src/main/generated/com/oboe/backend/cart/entity/QCart.java
@@ -31,8 +31,6 @@ public class QCart extends EntityPathBase<Cart> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final BooleanPath isActive = createBoolean("isActive");
-
     public final NumberPath<Integer> totalItems = createNumber("totalItems", Integer.class);
 
     public final NumberPath<java.math.BigDecimal> totalPrice = createNumber("totalPrice", java.math.BigDecimal.class);

--- a/backend/src/main/java/com/oboe/backend/cart/controller/CartController.java
+++ b/backend/src/main/java/com/oboe/backend/cart/controller/CartController.java
@@ -1,0 +1,191 @@
+package com.oboe.backend.cart.controller;
+
+import com.oboe.backend.cart.dto.request.CartItemRequest;
+import com.oboe.backend.cart.dto.request.UpdateQuantityRequest;
+import com.oboe.backend.cart.dto.response.CartItemResponse;
+import com.oboe.backend.cart.dto.response.CartResponse;
+import com.oboe.backend.cart.dto.response.CartSummaryResponse;
+import com.oboe.backend.cart.service.CartService;
+import com.oboe.backend.common.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/carts")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "장바구니", description = "장바구니 관리 API")
+public class CartController {
+
+  private final CartService cartService;
+
+  /**
+   * 사용자의 장바구니 조회
+   */
+  @Operation(summary = "장바구니 조회", description = "사용자의 장바구니 정보를 조회합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 필요"),
+      @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @GetMapping
+  public ResponseEntity<ResponseDto<CartResponse>> getCart(
+      @Parameter(description = "JWT 토큰", required = true)
+      @RequestHeader("Authorization") String authorization) {
+    CartResponse cartResponse = CartResponse.from(cartService.getCartByUser(authorization));
+
+    return ResponseEntity.ok(ResponseDto.success("장바구니 조회 성공", cartResponse));
+  }
+
+  /**
+   * 장바구니에 상품 추가
+   */
+  @Operation(summary = "상품 추가", description = "장바구니에 상품을 추가합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "추가 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (수량이 0 이하 등)"),
+      @ApiResponse(responseCode = "401", description = "인증 필요"),
+      @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음"),
+      @ApiResponse(responseCode = "409", description = "재고 부족, 판매 중지된 상품, 또는 재고 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @PostMapping("/items")
+  public ResponseEntity<ResponseDto<CartItemResponse>> addCartItem(
+      @Parameter(description = "JWT 토큰", required = true)
+      @RequestHeader("Authorization") String authorization,
+      @Valid @RequestBody CartItemRequest request) {
+    CartItemResponse cartItemResponse = CartItemResponse.from(
+        cartService.addCartItem(authorization, request));
+
+    return ResponseEntity.ok(ResponseDto.success("상품이 장바구니에 추가되었습니다", cartItemResponse));
+  }
+
+  /**
+   * 장바구니 아이템 수량 변경
+   */
+  @Operation(summary = "수량 변경", description = "장바구니 아이템의 수량을 변경합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "변경 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (수량이 0 이하 등)"),
+      @ApiResponse(responseCode = "401", description = "인증 필요"),
+      @ApiResponse(responseCode = "403", description = "장바구니 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "장바구니 아이템 또는 상품을 찾을 수 없음"),
+      @ApiResponse(responseCode = "409", description = "재고 부족, 판매 중지된 상품, 또는 재고 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @PutMapping("/items/{itemId}")
+  public ResponseEntity<ResponseDto<CartItemResponse>> updateCartItemQuantity(
+      @Parameter(description = "JWT 토큰", required = true)
+      @RequestHeader("Authorization") String authorization,
+      @Parameter(description = "장바구니 아이템 ID", required = true)
+      @PathVariable Long itemId,
+      @RequestBody UpdateQuantityRequest request) {
+
+    log.info("장바구니 아이템 수량 변경 요청 - 아이템 ID: {}, 새 수량: {}",
+        itemId, request.getQuantity());
+
+    CartItemResponse cartItemResponse = CartItemResponse.from(
+        cartService.updateCartItemQuantity(authorization, itemId, request.getQuantity()));
+
+    return ResponseEntity.ok(ResponseDto.success("수량이 변경되었습니다", cartItemResponse));
+  }
+
+  /**
+   * 장바구니에서 아이템 제거
+   */
+  @Operation(summary = "아이템 제거", description = "장바구니에서 특정 아이템을 제거합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "제거 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 필요"),
+      @ApiResponse(responseCode = "403", description = "장바구니 접근 권한 없음"),
+      @ApiResponse(responseCode = "404", description = "장바구니 아이템을 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @DeleteMapping("/items/{itemId}")
+  public ResponseEntity<ResponseDto<Void>> removeCartItem(
+      @Parameter(description = "JWT 토큰", required = true)
+      @RequestHeader("Authorization") String authorization,
+      @Parameter(description = "장바구니 아이템 ID", required = true)
+      @PathVariable Long itemId) {
+
+    log.info("장바구니 아이템 제거 요청 - 아이템 ID: {}", itemId);
+
+    cartService.removeCartItem(authorization, itemId);
+
+    return ResponseEntity.ok(ResponseDto.success("상품이 장바구니에서 제거되었습니다", null));
+  }
+
+  /**
+   * 장바구니 전체 비우기
+   */
+  @Operation(summary = "장바구니 비우기", description = "장바구니의 모든 아이템을 제거합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "비우기 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 필요"),
+      @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @DeleteMapping("/items")
+  public ResponseEntity<ResponseDto<Void>> clearCart(
+      @Parameter(description = "JWT 토큰", required = true)
+      @RequestHeader("Authorization") String authorization) {
+    cartService.clearCart(authorization);
+
+    return ResponseEntity.ok(ResponseDto.success("장바구니가 비워졌습니다", null));
+  }
+
+  /**
+   * 장바구니 요약 정보 조회
+   */
+  @Operation(summary = "장바구니 요약", description = "장바구니의 요약 정보를 조회합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 필요"),
+      @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @GetMapping("/summary")
+  public ResponseEntity<ResponseDto<CartSummaryResponse>> getCartSummary(
+      @Parameter(description = "JWT 토큰", required = true)
+      @RequestHeader("Authorization") String authorization) {
+    CartSummaryResponse summaryResponse = cartService.getCartSummary(authorization);
+
+    return ResponseEntity.ok(ResponseDto.success("장바구니 요약 조회 성공", summaryResponse));
+  }
+
+  /**
+   * 장바구니 유효성 검증
+   */
+  @Operation(summary = "유효성 검증", description = "장바구니의 상품 재고 및 가격을 검증합니다 (재고/가격 변경 경고 포함)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "검증 완료 (재고 부족이나 가격 변경이 있어도 경고만 표시)"),
+      @ApiResponse(responseCode = "401", description = "인증 필요"),
+      @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 오류")
+  })
+  @PostMapping("/validate")
+  public ResponseEntity<ResponseDto<CartResponse>> validateCart(
+      @Parameter(description = "JWT 토큰", required = true)
+      @RequestHeader("Authorization") String authorization) {
+    CartResponse cartResponse = CartResponse.from(cartService.validateCart(authorization));
+
+    return ResponseEntity.ok(ResponseDto.success("장바구니 유효성 검증 완료", cartResponse));
+  }
+}

--- a/backend/src/main/java/com/oboe/backend/cart/dto/CartDto.java
+++ b/backend/src/main/java/com/oboe/backend/cart/dto/CartDto.java
@@ -1,0 +1,22 @@
+package com.oboe.backend.cart.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartDto {
+
+  private Long cartId;
+  private Integer totalItems;
+  private BigDecimal totalPrice;
+  private Integer itemCount;
+  private List<CartItemDto> items;
+}
+

--- a/backend/src/main/java/com/oboe/backend/cart/dto/CartItemDto.java
+++ b/backend/src/main/java/com/oboe/backend/cart/dto/CartItemDto.java
@@ -1,0 +1,28 @@
+package com.oboe.backend.cart.dto;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartItemDto {
+
+  private Long cartItemId;
+  private Long productId;
+  private String productName;
+  private String productImage;
+  private Integer quantity;
+  private BigDecimal unitPrice;
+  private BigDecimal totalPrice;
+  private String brand;
+  private String condition;
+  private Boolean isStockAvailable;
+  private Boolean isPriceChanged;
+  private String warningMessage;
+}
+

--- a/backend/src/main/java/com/oboe/backend/cart/dto/request/CartItemRequest.java
+++ b/backend/src/main/java/com/oboe/backend/cart/dto/request/CartItemRequest.java
@@ -1,0 +1,23 @@
+package com.oboe.backend.cart.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartItemRequest {
+
+  @NotNull(message = "상품 ID는 필수입니다")
+  private Long productId;
+
+  @NotNull(message = "수량은 필수입니다")
+  @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+  private Integer quantity;
+}
+

--- a/backend/src/main/java/com/oboe/backend/cart/dto/request/UpdateQuantityRequest.java
+++ b/backend/src/main/java/com/oboe/backend/cart/dto/request/UpdateQuantityRequest.java
@@ -1,0 +1,18 @@
+package com.oboe.backend.cart.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateQuantityRequest {
+
+  @NotNull(message = "수량은 필수입니다")
+  @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+  private Integer quantity;
+}
+

--- a/backend/src/main/java/com/oboe/backend/cart/dto/response/CartItemResponse.java
+++ b/backend/src/main/java/com/oboe/backend/cart/dto/response/CartItemResponse.java
@@ -1,0 +1,46 @@
+package com.oboe.backend.cart.dto.response;
+
+import com.oboe.backend.cart.dto.CartItemDto;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartItemResponse {
+
+  private Long cartItemId;
+  private Long productId;
+  private String productName;
+  private String productImage;
+  private Integer quantity;
+  private BigDecimal unitPrice;
+  private BigDecimal totalPrice;
+  private String brand;
+  private String condition;
+  private Boolean isStockAvailable;
+  private Boolean isPriceChanged;
+  private String warningMessage;
+
+  public static CartItemResponse from(CartItemDto cartItemDto) {
+    return CartItemResponse.builder()
+        .cartItemId(cartItemDto.getCartItemId())
+        .productId(cartItemDto.getProductId())
+        .productName(cartItemDto.getProductName())
+        .productImage(cartItemDto.getProductImage())
+        .quantity(cartItemDto.getQuantity())
+        .unitPrice(cartItemDto.getUnitPrice())
+        .totalPrice(cartItemDto.getTotalPrice())
+        .brand(cartItemDto.getBrand())
+        .condition(cartItemDto.getCondition())
+        .isStockAvailable(cartItemDto.getIsStockAvailable())
+        .isPriceChanged(cartItemDto.getIsPriceChanged())
+        .warningMessage(cartItemDto.getWarningMessage())
+        .build();
+  }
+}
+

--- a/backend/src/main/java/com/oboe/backend/cart/dto/response/CartResponse.java
+++ b/backend/src/main/java/com/oboe/backend/cart/dto/response/CartResponse.java
@@ -1,0 +1,37 @@
+package com.oboe.backend.cart.dto.response;
+
+import com.oboe.backend.cart.dto.CartDto;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartResponse {
+
+  private Long cartId;
+  private Integer totalItems;
+  private BigDecimal totalPrice;
+  private Integer itemCount;
+  private List<CartItemResponse> items;
+
+  public static CartResponse from(CartDto cartDto) {
+    List<CartItemResponse> itemResponses = cartDto.getItems().stream()
+        .map(CartItemResponse::from)
+        .toList();
+
+    return CartResponse.builder()
+        .cartId(cartDto.getCartId())
+        .totalItems(cartDto.getTotalItems())
+        .totalPrice(cartDto.getTotalPrice())
+        .itemCount(cartDto.getItemCount())
+        .items(itemResponses)
+        .build();
+  }
+}
+

--- a/backend/src/main/java/com/oboe/backend/cart/dto/response/CartSummaryResponse.java
+++ b/backend/src/main/java/com/oboe/backend/cart/dto/response/CartSummaryResponse.java
@@ -1,0 +1,44 @@
+package com.oboe.backend.cart.dto.response;
+
+import com.oboe.backend.cart.dto.CartDto;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartSummaryResponse {
+
+  private Integer totalItems;
+  private BigDecimal totalPrice;
+  private Integer itemCount;
+  private BigDecimal estimatedDeliveryFee;
+  private Boolean hasIssues;
+  private Integer issueCount;
+
+  public static CartSummaryResponse from(CartDto cartDto) {
+    // 배송비는 5만원 이상 무료, 미만은 3000원
+    BigDecimal deliveryFee = cartDto.getTotalPrice().compareTo(new BigDecimal("50000")) >= 0 
+        ? BigDecimal.ZERO 
+        : new BigDecimal("3000");
+
+    // 이슈 개수 계산 (재고 부족, 가격 변경 등)
+    int issueCount = (int) cartDto.getItems().stream()
+        .filter(item -> !item.getIsStockAvailable() || item.getIsPriceChanged())
+        .count();
+
+    return CartSummaryResponse.builder()
+        .totalItems(cartDto.getTotalItems())
+        .totalPrice(cartDto.getTotalPrice())
+        .itemCount(cartDto.getItemCount())
+        .estimatedDeliveryFee(deliveryFee)
+        .hasIssues(issueCount > 0)
+        .issueCount(issueCount)
+        .build();
+  }
+}
+

--- a/backend/src/main/java/com/oboe/backend/cart/entity/Cart.java
+++ b/backend/src/main/java/com/oboe/backend/cart/entity/Cart.java
@@ -51,9 +51,6 @@ public class Cart extends BaseTimeEntity {
   @Builder.Default
   private BigDecimal totalPrice = BigDecimal.ZERO; // 총 금액
 
-  @Column(nullable = false)
-  @Builder.Default
-  private Boolean isActive = true; // 장바구니 활성화 여부
 
   // ==============================
   // 도메인 비즈니스 메서드들
@@ -65,7 +62,7 @@ public class Cart extends BaseTimeEntity {
   public void addCartItem(CartItem cartItem) {
     // 이미 같은 상품이 있는지 확인
     CartItem existingItem = findCartItemByProduct(cartItem.getProduct().getId());
-    
+
     if (existingItem != null) {
       // 기존 상품이 있으면 수량 증가
       existingItem.increaseQuantity(cartItem.getQuantity());
@@ -74,7 +71,7 @@ public class Cart extends BaseTimeEntity {
       cartItems.add(cartItem);
       cartItem.setCart(this);
     }
-    
+
     recalculateTotals();
   }
 
@@ -114,11 +111,11 @@ public class Cart extends BaseTimeEntity {
   /**
    * 총 개수와 총 금액 재계산
    */
-  private void recalculateTotals() {
+  public void recalculateTotals() {
     this.totalItems = cartItems.stream()
         .mapToInt(CartItem::getQuantity)
         .sum();
-    
+
     this.totalPrice = cartItems.stream()
         .map(CartItem::getTotalPrice)
         .reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -132,19 +129,6 @@ public class Cart extends BaseTimeEntity {
     recalculateTotals();
   }
 
-  /**
-   * 장바구니 비활성화
-   */
-  public void deactivate() {
-    this.isActive = false;
-  }
-
-  /**
-   * 장바구니 활성화
-   */
-  public void activate() {
-    this.isActive = true;
-  }
 
   /**
    * 장바구니가 비어있는지 확인
@@ -176,9 +160,9 @@ public class Cart extends BaseTimeEntity {
   }
 
   /**
-   * 주문 가능 여부 확인 (장바구니가 비어있지 않고 활성화되어 있어야 함)
+   * 주문 가능 여부 확인 (장바구니가 비어있지 않아야 함)
    */
   public boolean canPlaceOrder() {
-    return isActive && !isEmpty();
+    return !isEmpty();
   }
 }

--- a/backend/src/main/java/com/oboe/backend/cart/entity/CartItem.java
+++ b/backend/src/main/java/com/oboe/backend/cart/entity/CartItem.java
@@ -60,7 +60,7 @@ public class CartItem extends BaseTimeEntity {
     if (additionalQuantity == null || additionalQuantity <= 0) {
       throw new IllegalArgumentException("추가할 수량은 0보다 커야 합니다.");
     }
-    
+
     this.quantity += additionalQuantity;
     calculateTotalPrice();
   }
@@ -72,11 +72,11 @@ public class CartItem extends BaseTimeEntity {
     if (decreaseQuantity == null || decreaseQuantity <= 0) {
       throw new IllegalArgumentException("감소할 수량은 0보다 커야 합니다.");
     }
-    
+
     if (this.quantity <= decreaseQuantity) {
       throw new IllegalArgumentException("수량이 부족합니다. 현재 수량: " + this.quantity);
     }
-    
+
     this.quantity -= decreaseQuantity;
     calculateTotalPrice();
   }
@@ -88,7 +88,7 @@ public class CartItem extends BaseTimeEntity {
     if (quantity == null || quantity <= 0) {
       throw new IllegalArgumentException("수량은 0보다 커야 합니다.");
     }
-    
+
     this.quantity = quantity;
     calculateTotalPrice();
   }
@@ -109,7 +109,7 @@ public class CartItem extends BaseTimeEntity {
     if (unitPrice == null || unitPrice.compareTo(BigDecimal.ZERO) < 0) {
       throw new IllegalArgumentException("단위 가격은 0 이상이어야 합니다.");
     }
-    
+
     this.unitPrice = unitPrice;
     calculateTotalPrice();
   }
@@ -135,16 +135,16 @@ public class CartItem extends BaseTimeEntity {
    * 상품 재고 확인
    */
   public boolean isStockAvailable() {
-    return product != null && product.getStockQuantity() != null && 
-           product.getStockQuantity() >= quantity;
+    return product != null && product.getStockQuantity() != null &&
+        product.getStockQuantity() >= quantity;
   }
 
   /**
    * 상품이 판매 중인지 확인
    */
   public boolean isProductAvailable() {
-    return product != null && product.getProductStatus() != null && 
-           product.getProductStatus().isAvailable();
+    return product != null && product.getProductStatus() != null &&
+        product.getProductStatus().isAvailable();
   }
 
   /**
@@ -161,7 +161,7 @@ public class CartItem extends BaseTimeEntity {
     if (product == null || product.getPrice() == null || unitPrice == null) {
       return false;
     }
-    
+
     return !product.getPrice().equals(unitPrice);
   }
 
@@ -172,14 +172,14 @@ public class CartItem extends BaseTimeEntity {
     if (!isPriceChanged()) {
       return null;
     }
-    
+
     BigDecimal currentPrice = product.getPrice();
     if (currentPrice.compareTo(unitPrice) > 0) {
-      return String.format("상품 가격이 %.0f원에서 %.0f원으로 인상되었습니다.", 
-                          unitPrice, currentPrice);
+      return String.format("상품 가격이 %.0f원에서 %.0f원으로 인상되었습니다.",
+          unitPrice, currentPrice);
     } else {
-      return String.format("상품 가격이 %.0f원에서 %.0f원으로 인하되었습니다.", 
-                          unitPrice, currentPrice);
+      return String.format("상품 가격이 %.0f원에서 %.0f원으로 인하되었습니다.",
+          unitPrice, currentPrice);
     }
   }
 
@@ -190,12 +190,12 @@ public class CartItem extends BaseTimeEntity {
     if (product == null || product.getStockQuantity() == null) {
       return "재고 정보를 확인할 수 없습니다.";
     }
-    
+
     if (product.getStockQuantity() < quantity) {
-      return String.format("재고가 부족합니다. 현재 재고: %d개, 요청 수량: %d개", 
-                          product.getStockQuantity(), quantity);
+      return String.format("재고가 부족합니다. 현재 재고: %d개, 요청 수량: %d개",
+          product.getStockQuantity(), quantity);
     }
-    
+
     return null;
   }
 }

--- a/backend/src/main/java/com/oboe/backend/cart/repository/CartItemRepository.java
+++ b/backend/src/main/java/com/oboe/backend/cart/repository/CartItemRepository.java
@@ -34,13 +34,13 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
   Long countByProductId(@Param("productId") Long productId);
 
   /**
-   * 사용자 ID로 장바구니 아이템 목록 조회 (활성 장바구니만)
+   * 사용자 ID로 장바구니 아이템 목록 조회
    */
   @Query("SELECT ci FROM CartItem ci " +
-         "JOIN ci.cart c " +
-         "WHERE c.user.id = :userId AND c.isActive = true " +
-         "ORDER BY ci.createdAt ASC")
-  List<CartItem> findByUserIdAndCartActive(@Param("userId") Long userId);
+      "JOIN ci.cart c " +
+      "WHERE c.user.id = :userId " +
+      "ORDER BY ci.createdAt ASC")
+  List<CartItem> findByUserId(@Param("userId") Long userId);
 
   /**
    * 장바구니 ID로 장바구니 아이템 개수 조회
@@ -66,23 +66,23 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
    * 가격이 변경된 장바구니 아이템 목록 조회
    */
   @Query("SELECT ci FROM CartItem ci " +
-         "WHERE ci.cart.id = :cartId " +
-         "AND ci.unitPrice != ci.product.price")
+      "WHERE ci.cart.id = :cartId " +
+      "AND ci.unitPrice != ci.product.price")
   List<CartItem> findPriceChangedItemsByCartId(@Param("cartId") Long cartId);
 
   /**
    * 재고가 부족한 장바구니 아이템 목록 조회
    */
   @Query("SELECT ci FROM CartItem ci " +
-         "WHERE ci.cart.id = :cartId " +
-         "AND ci.quantity > ci.product.stockQuantity")
+      "WHERE ci.cart.id = :cartId " +
+      "AND ci.quantity > ci.product.stockQuantity")
   List<CartItem> findStockShortageItemsByCartId(@Param("cartId") Long cartId);
 
   /**
    * 판매 중지된 상품의 장바구니 아이템 목록 조회
    */
   @Query("SELECT ci FROM CartItem ci " +
-         "WHERE ci.cart.id = :cartId " +
-         "AND ci.product.productStatus != 'ACTIVE'")
+      "WHERE ci.cart.id = :cartId " +
+      "AND ci.product.productStatus != 'ACTIVE'")
   List<CartItem> findUnavailableProductItemsByCartId(@Param("cartId") Long cartId);
 }

--- a/backend/src/main/java/com/oboe/backend/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/oboe/backend/cart/repository/CartRepository.java
@@ -14,29 +14,24 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
   /**
    * 사용자 ID로 장바구니 조회
    */
-  @Query("SELECT c FROM Cart c WHERE c.user.id = :userId AND c.isActive = true")
-  Optional<Cart> findByUserIdAndActive(@Param("userId") Long userId);
+  @Query("SELECT c FROM Cart c WHERE c.user.id = :userId")
+  Optional<Cart> findByUserId(@Param("userId") Long userId);
 
   /**
    * 사용자로 장바구니 조회
    */
-  Optional<Cart> findByUserAndIsActiveTrue(User user);
+  Optional<Cart> findByUser(User user);
 
   /**
-   * 사용자의 활성 장바구니 존재 여부 확인
+   * 사용자의 장바구니 존재 여부 확인
    */
-  boolean existsByUserAndIsActiveTrue(User user);
+  boolean existsByUser(User user);
 
   /**
-   * 사용자 ID로 활성 장바구니 존재 여부 확인
+   * 사용자 ID로 장바구니 존재 여부 확인
    */
-  @Query("SELECT COUNT(c) > 0 FROM Cart c WHERE c.user.id = :userId AND c.isActive = true")
-  boolean existsByUserIdAndActive(@Param("userId") Long userId);
-
-  /**
-   * 비활성 장바구니들 삭제 (사용자 탈퇴 시 등)
-   */
-  void deleteByUserAndIsActiveFalse(User user);
+  @Query("SELECT COUNT(c) > 0 FROM Cart c WHERE c.user.id = :userId")
+  boolean existsByUserId(@Param("userId") Long userId);
 
   /**
    * 사용자의 모든 장바구니 삭제

--- a/backend/src/main/java/com/oboe/backend/cart/service/CartService.java
+++ b/backend/src/main/java/com/oboe/backend/cart/service/CartService.java
@@ -1,0 +1,343 @@
+package com.oboe.backend.cart.service;
+
+import com.oboe.backend.cart.dto.CartDto;
+import com.oboe.backend.cart.dto.CartItemDto;
+import com.oboe.backend.cart.dto.request.CartItemRequest;
+import com.oboe.backend.cart.dto.response.CartSummaryResponse;
+import com.oboe.backend.cart.entity.Cart;
+import com.oboe.backend.cart.entity.CartItem;
+import com.oboe.backend.cart.repository.CartItemRepository;
+import com.oboe.backend.cart.repository.CartRepository;
+import com.oboe.backend.common.exception.CustomException;
+import com.oboe.backend.common.exception.ErrorCode;
+import com.oboe.backend.common.service.TokenProcessor;
+import com.oboe.backend.product.entity.Product;
+import com.oboe.backend.product.repository.ProductRepository;
+import com.oboe.backend.user.entity.User;
+import com.oboe.backend.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class CartService {
+
+  private final CartRepository cartRepository;
+  private final CartItemRepository cartItemRepository;
+  private final ProductRepository productRepository;
+  private final UserRepository userRepository;
+  private final TokenProcessor tokenProcessor;
+
+  /**
+   * 사용자의 장바구니 조회
+   */
+  public CartDto getCartByUser(String authorization) {
+    Long userId = getUserIdFromToken(authorization, "장바구니 조회");
+    Cart cart = findOrCreateCart(userId);
+    return convertToCartDto(cart);
+  }
+
+  /**
+   * 장바구니에 상품 추가
+   */
+  @Transactional
+  public CartItemDto addCartItem(String authorization, CartItemRequest request) {
+    Long userId = getUserIdFromToken(authorization, "장바구니 상품 추가");
+
+    // 사용자 장바구니 조회 또는 생성
+    Cart cart = findOrCreateCart(userId);
+
+    // 기존 장바구니 아이템 확인
+    Optional<CartItem> existingItem = cartItemRepository.findByCartIdAndProductId(
+        cart.getId(), request.getProductId());
+
+    // 최종 요청 수량 계산
+    Integer finalQuantity = request.getQuantity();
+    if (existingItem.isPresent()) {
+      finalQuantity += existingItem.get().getQuantity();
+    }
+
+    // 상품 존재, 판매 상태, 재고 한번에 검증
+    Product product = validateProductForCart(request.getProductId(), finalQuantity);
+
+    CartItem cartItem;
+    if (existingItem.isPresent()) {
+      // 기존 아이템 수량 증가
+      cartItem = existingItem.get();
+      cartItem.increaseQuantity(request.getQuantity());
+    } else {
+      // 새 아이템 생성
+      cartItem = CartItem.builder()
+          .cart(cart)
+          .product(product)
+          .quantity(request.getQuantity())
+          .unitPrice(product.getPrice())
+          .totalPrice(product.getPrice().multiply(new java.math.BigDecimal(request.getQuantity())))
+          .build();
+    }
+
+    cartItemRepository.save(cartItem);
+    cart.addCartItem(cartItem);
+    cartRepository.save(cart);
+
+    log.info("상품 {}이(가) 장바구니에 추가되었습니다. 사용자 ID: {}, 수량: {}",
+        product.getName(), userId, request.getQuantity());
+
+    return convertToCartItemDto(cartItem);
+  }
+
+  /**
+   * 장바구니 아이템 수량 변경
+   */
+  @Transactional
+  public CartItemDto updateCartItemQuantity(String authorization, Long cartItemId,
+      Integer newQuantity) {
+    Long userId = getUserIdFromToken(authorization, "장바구니 아이템 수량 변경");
+    CartItem cartItem = findCartItemById(cartItemId);
+    validateCartOwnership(userId, cartItem.getCart().getId());
+
+    // 상품 판매 상태 및 재고 검증
+    validateProductForCart(cartItem.getProduct().getId(), newQuantity);
+
+    cartItem.setQuantity(newQuantity);
+    cartItemRepository.save(cartItem);
+
+    // 장바구니 총액 재계산
+    Cart cart = cartItem.getCart();
+    cart.recalculateTotals();
+    cartRepository.save(cart);
+
+    log.info("장바구니 아이템 수량이 변경되었습니다. 사용자 ID: {}, 아이템 ID: {}, 새 수량: {}",
+        userId, cartItemId, newQuantity);
+
+    return convertToCartItemDto(cartItem);
+  }
+
+  /**
+   * 장바구니에서 아이템 제거
+   */
+  @Transactional
+  public void removeCartItem(String authorization, Long cartItemId) {
+    Long userId = getUserIdFromToken(authorization, "장바구니 아이템 제거");
+    CartItem cartItem = findCartItemById(cartItemId);
+    validateCartOwnership(userId, cartItem.getCart().getId());
+
+    Cart cart = cartItem.getCart();
+    cart.removeCartItem(cartItem.getProduct().getId());
+
+    cartItemRepository.delete(cartItem);
+    cartRepository.save(cart);
+
+    log.info("장바구니 아이템이 제거되었습니다. 사용자 ID: {}, 아이템 ID: {}", userId, cartItemId);
+  }
+
+  /**
+   * 장바구니 비우기
+   */
+  @Transactional
+  public void clearCart(String authorization) {
+    Long userId = getUserIdFromToken(authorization, "장바구니 비우기");
+    Cart cart = findOrCreateCart(userId);
+    cart.clear();
+    cartRepository.save(cart);
+
+    log.info("장바구니가 비워졌습니다. 사용자 ID: {}", userId);
+  }
+
+  /**
+   * 장바구니 요약 정보 조회
+   */
+  public CartSummaryResponse getCartSummary(String authorization) {
+    Long userId = getUserIdFromToken(authorization, "장바구니 요약 조회");
+    Cart cart = findOrCreateCart(userId);
+    CartDto cartDto = convertToCartDto(cart);
+    return CartSummaryResponse.from(cartDto);
+  }
+
+  /**
+   * 장바구니 유효성 검증
+   */
+  public CartDto validateCart(String authorization) {
+    Long userId = getUserIdFromToken(authorization, "장바구니 유효성 검증");
+    Cart cart = findOrCreateCart(userId);
+
+    // 각 아이템의 유효성 검증
+    for (CartItem cartItem : cart.getCartItems()) {
+      // 가격 변경 확인
+      cartItem.updateUnitPriceFromProduct();
+
+      // 재고 확인
+      if (!cartItem.isStockAvailable()) {
+        log.warn("재고 부족: 상품 ID {}, 요청 수량 {}, 사용 가능 수량 {}",
+            cartItem.getProduct().getId(),
+            cartItem.getQuantity(),
+            cartItem.getProduct().getStockQuantity());
+      }
+
+      // 판매 상태 확인
+      if (!cartItem.isProductAvailable()) {
+        log.warn("판매 중지된 상품: 상품 ID {}", cartItem.getProduct().getId());
+      }
+    }
+
+    cartRepository.save(cart);
+    return convertToCartDto(cart);
+  }
+
+  // ==============================
+  // 공통 구현 메소드
+  // ==============================
+
+  /**
+   * 사용자 ID로 장바구니 조회, 없으면 새로 생성
+   */
+  private Cart findOrCreateCart(Long userId) {
+    return cartRepository.findByUserId(userId)
+        .orElseGet(() -> createNewCart(userId));
+  }
+
+  /**
+   * 새로운 장바구니 생성
+   */
+  private Cart createNewCart(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "사용자 ID: " + userId));
+
+    Cart cart = Cart.builder()
+        .user(user)
+        .totalItems(0)
+        .totalPrice(java.math.BigDecimal.ZERO)
+        .build();
+
+    return cartRepository.save(cart);
+  }
+
+  /**
+   * Authorization 토큰에서 사용자 ID 추출
+   */
+  private Long getUserIdFromToken(String authorization, String context) {
+    String email = tokenProcessor.extractEmailFromBearerToken(authorization, context);
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, "이메일: " + email));
+
+    return user.getId();
+  }
+
+
+  /**
+   * 장바구니용 상품 종합 검증 (존재, 판매상태, 재고)
+   */
+  private Product validateProductForCart(Long productId, Integer requestedQuantity) {
+    Product product = productRepository.findById(productId)
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND, "상품 ID: " + productId));
+
+    // 판매 상태 확인
+    if (!product.getProductStatus().isAvailable()) {
+      throw new CustomException(ErrorCode.CART_PRODUCT_UNAVAILABLE, "상품명: " + product.getName());
+    }
+
+    // 재고 확인
+    if (product.getStockQuantity() == null) {
+      throw new CustomException(ErrorCode.PRODUCT_INVALID_STOCK,
+          "상품 재고 정보가 없습니다. 상품 ID: " + product.getId());
+    }
+
+    if (product.getStockQuantity() < requestedQuantity) {
+      String errorMessage = String.format(
+          "재고가 부족합니다. 상품명: %s, 현재 재고: %d개, 요청 수량: %d개",
+          product.getName(),
+          product.getStockQuantity(),
+          requestedQuantity);
+
+      log.warn("재고 부족 - {}", errorMessage);
+      throw new CustomException(ErrorCode.CART_INSUFFICIENT_STOCK, errorMessage);
+    }
+
+    log.debug("상품 검증 통과 - 상품 ID: {}, 요청 수량: {}, 현재 재고: {}",
+        product.getId(), requestedQuantity, product.getStockQuantity());
+
+    return product;
+  }
+
+  /**
+   * 장바구니 아이템 ID로 아이템 조회
+   */
+  private CartItem findCartItemById(Long cartItemId) {
+    return cartItemRepository.findById(cartItemId)
+        .orElseThrow(
+            () -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND, "아이템 ID: " + cartItemId));
+  }
+
+  /**
+   * 장바구니 소유권 검증 (사용자가 해당 장바구니의 소유자인지 확인)
+   */
+  private void validateCartOwnership(Long userId, Long cartId) {
+    Cart cart = cartRepository.findById(cartId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND, "장바구니 ID: " + cartId));
+
+    if (!cart.getUser().getId().equals(userId)) {
+      throw new CustomException(ErrorCode.CART_ACCESS_DENIED);
+    }
+  }
+
+  /**
+   * Cart 엔티티를 CartDto로 변환
+   */
+  private CartDto convertToCartDto(Cart cart) {
+    List<CartItemDto> itemDtos = cart.getCartItems().stream()
+        .map(this::convertToCartItemDto)
+        .toList();
+
+    return CartDto.builder()
+        .cartId(cart.getId())
+        .totalItems(cart.getTotalItems())
+        .totalPrice(cart.getTotalPrice())
+        .itemCount(cart.getItemCount())
+        .items(itemDtos)
+        .build();
+  }
+
+  /**
+   * CartItem 엔티티를 CartItemDto로 변환 (재고/가격 변경 경고 메시지 포함)
+   */
+  private CartItemDto convertToCartItemDto(CartItem cartItem) {
+    String warningMessage = null;
+    if (!cartItem.isStockAvailable()) {
+      warningMessage = cartItem.getStockShortageMessage();
+    } else if (cartItem.isPriceChanged()) {
+      warningMessage = cartItem.getPriceChangeMessage();
+    }
+
+    return CartItemDto.builder()
+        .cartItemId(cartItem.getId())
+        .productId(cartItem.getProduct().getId())
+        .productName(cartItem.getProduct().getName())
+        .productImage(getProductImage(cartItem.getProduct()))
+        .quantity(cartItem.getQuantity())
+        .unitPrice(cartItem.getUnitPrice())
+        .totalPrice(cartItem.getTotalPrice())
+        .brand(cartItem.getProduct().getBrand())
+        .condition(
+            cartItem.getProduct().getCondition() != null ? cartItem.getProduct().getCondition()
+                .name() : null)
+        .isStockAvailable(cartItem.isStockAvailable())
+        .isPriceChanged(cartItem.isPriceChanged())
+        .warningMessage(warningMessage)
+        .build();
+  }
+
+  /**
+   * 상품의 대표 이미지 URL 추출 (첫 번째 이미지)
+   */
+  private String getProductImage(Product product) {
+    return product.getProductImages().isEmpty() ? null
+        : product.getProductImages().get(0).getImageUrl();
+  }
+
+}

--- a/backend/src/main/java/com/oboe/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/oboe/backend/common/exception/ErrorCode.java
@@ -60,7 +60,17 @@ public enum ErrorCode {
   SMS_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
   SMS_VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, "SMS 인증이 필요합니다."),
   SMS_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "SMS 발송 한도를 초과했습니다."),
-  SMS_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "SMS 서비스를 사용할 수 없습니다.");
+  SMS_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "SMS 서비스를 사용할 수 없습니다."),
+
+  // 장바구니 관련 오류
+  CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
+  CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 아이템을 찾을 수 없습니다."),
+  CART_ACCESS_DENIED(HttpStatus.FORBIDDEN, "장바구니에 접근할 권한이 없습니다."),
+  CART_ITEM_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "장바구니 아이템 수량이 올바르지 않습니다."),
+  CART_EMPTY(HttpStatus.BAD_REQUEST, "장바구니가 비어있습니다."),
+  CART_PRODUCT_UNAVAILABLE(HttpStatus.CONFLICT, "현재 판매 중인 상품이 아닙니다."),
+  CART_INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),
+  CART_PRICE_CHANGED(HttpStatus.CONFLICT, "상품 가격이 변경되었습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/backend/src/test/java/com/oboe/backend/cart/controller/CartControllerTest.java
+++ b/backend/src/test/java/com/oboe/backend/cart/controller/CartControllerTest.java
@@ -1,0 +1,433 @@
+package com.oboe.backend.cart.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oboe.backend.cart.dto.CartDto;
+import com.oboe.backend.cart.dto.CartItemDto;
+import com.oboe.backend.cart.dto.request.CartItemRequest;
+import com.oboe.backend.cart.dto.request.UpdateQuantityRequest;
+import com.oboe.backend.cart.dto.response.CartSummaryResponse;
+import com.oboe.backend.cart.service.CartService;
+import com.oboe.backend.common.exception.CustomException;
+import com.oboe.backend.common.exception.ErrorCode;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("CartController 테스트")
+class CartControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private CartService cartService;
+
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String BEARER_TOKEN = "Bearer valid-token";
+
+  @Test
+  @DisplayName("장바구니 조회 성공")
+  void getCart_Success() throws Exception {
+    // given
+    List<CartItemDto> items = new ArrayList<>();
+    items.add(CartItemDto.builder()
+        .cartItemId(1L)
+        .productId(1L)
+        .productName("빈티지 데님 셔츠")
+        .quantity(2)
+        .unitPrice(new BigDecimal("150000"))
+        .totalPrice(new BigDecimal("300000"))
+        .brand("리바이스")
+        .condition("VERY_GOOD")
+        .isStockAvailable(true)
+        .isPriceChanged(false)
+        .build());
+
+    CartDto cartDto = CartDto.builder()
+        .cartId(1L)
+        .totalItems(2)
+        .totalPrice(new BigDecimal("300000"))
+        .itemCount(1)
+        .items(items)
+        .build();
+
+    given(cartService.getCartByUser(BEARER_TOKEN)).willReturn(cartDto);
+
+    // when & then
+    mockMvc.perform(get("/api/v1/carts")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.message").value("장바구니 조회 성공"))
+        .andExpect(jsonPath("$.data.cartId").value(1L))
+        .andExpect(jsonPath("$.data.totalItems").value(2))
+        .andExpect(jsonPath("$.data.totalPrice").value(300000))
+        .andExpect(jsonPath("$.data.itemCount").value(1))
+        .andExpect(jsonPath("$.data.items").isArray())
+        .andExpect(jsonPath("$.data.items[0].cartItemId").value(1L))
+        .andExpect(jsonPath("$.data.items[0].productName").value("빈티지 데님 셔츠"));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 사용자로 장바구니 조회 실패")
+  void getCart_InvalidUser_Failure() throws Exception {
+    // given
+    given(cartService.getCartByUser(BEARER_TOKEN))
+        .willThrow(new CustomException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다"));
+
+    // when & then
+    mockMvc.perform(get("/api/v1/carts")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+        .andDo(print())
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("장바구니에 상품 추가 성공")
+  void addCartItem_Success() throws Exception {
+    // given
+    CartItemRequest request = CartItemRequest.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+
+    CartItemDto cartItemDto = CartItemDto.builder()
+        .cartItemId(1L)
+        .productId(1L)
+        .productName("빈티지 데님 셔츠")
+        .quantity(3)
+        .unitPrice(new BigDecimal("150000"))
+        .totalPrice(new BigDecimal("450000"))
+        .brand("리바이스")
+        .condition("VERY_GOOD")
+        .isStockAvailable(true)
+        .isPriceChanged(false)
+        .build();
+
+    given(cartService.addCartItem(anyString(), any(CartItemRequest.class)))
+        .willReturn(cartItemDto);
+
+    // when & then
+    mockMvc.perform(post("/api/v1/carts/items")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.message").value("상품이 장바구니에 추가되었습니다"))
+        .andExpect(jsonPath("$.data.cartItemId").value(1L))
+        .andExpect(jsonPath("$.data.productId").value(1L))
+        .andExpect(jsonPath("$.data.quantity").value(3))
+        .andExpect(jsonPath("$.data.unitPrice").value(150000))
+        .andExpect(jsonPath("$.data.totalPrice").value(450000));
+  }
+
+  @Test
+  @DisplayName("재고 부족으로 상품 추가 실패")
+  void addCartItem_InsufficientStock_Failure() throws Exception {
+    // given
+    CartItemRequest request = CartItemRequest.builder()
+        .productId(1L)
+        .quantity(10)
+        .build();
+
+    given(cartService.addCartItem(anyString(), any(CartItemRequest.class)))
+        .willThrow(new CustomException(ErrorCode.CART_INSUFFICIENT_STOCK, "재고가 부족합니다"));
+
+    // when & then
+    mockMvc.perform(post("/api/v1/carts/items")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("판매 중지된 상품 추가 실패")
+  void addCartItem_ProductUnavailable_Failure() throws Exception {
+    // given
+    CartItemRequest request = CartItemRequest.builder()
+        .productId(1L)
+        .quantity(1)
+        .build();
+
+    given(cartService.addCartItem(anyString(), any(CartItemRequest.class)))
+        .willThrow(new CustomException(ErrorCode.CART_PRODUCT_UNAVAILABLE, "판매 중지된 상품입니다"));
+
+    // when & then
+    mockMvc.perform(post("/api/v1/carts/items")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 상품 추가 실패")
+  void addCartItem_ProductNotFound_Failure() throws Exception {
+    // given
+    CartItemRequest request = CartItemRequest.builder()
+        .productId(999L)
+        .quantity(1)
+        .build();
+
+    given(cartService.addCartItem(anyString(), any(CartItemRequest.class)))
+        .willThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND, "상품을 찾을 수 없습니다"));
+
+    // when & then
+    mockMvc.perform(post("/api/v1/carts/items")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("장바구니 아이템 수량 변경 성공")
+  void updateCartItemQuantity_Success() throws Exception {
+    // given
+    UpdateQuantityRequest request = new UpdateQuantityRequest(5);
+
+    CartItemDto cartItemDto = CartItemDto.builder()
+        .cartItemId(1L)
+        .productId(1L)
+        .productName("빈티지 데님 셔츠")
+        .quantity(5)
+        .unitPrice(new BigDecimal("150000"))
+        .totalPrice(new BigDecimal("750000"))
+        .brand("리바이스")
+        .condition("VERY_GOOD")
+        .isStockAvailable(true)
+        .isPriceChanged(false)
+        .build();
+
+    given(cartService.updateCartItemQuantity(anyString(), anyLong(), any(Integer.class)))
+        .willReturn(cartItemDto);
+
+    // when & then
+    mockMvc.perform(put("/api/v1/carts/items/1")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.message").value("수량이 변경되었습니다"))
+        .andExpect(jsonPath("$.data.quantity").value(5))
+        .andExpect(jsonPath("$.data.totalPrice").value(750000));
+  }
+
+  @Test
+  @DisplayName("재고 부족으로 수량 변경 실패")
+  void updateCartItemQuantity_InsufficientStock_Failure() throws Exception {
+    // given
+    UpdateQuantityRequest request = new UpdateQuantityRequest(15);
+
+    given(cartService.updateCartItemQuantity(anyString(), anyLong(), any(Integer.class)))
+        .willThrow(new CustomException(ErrorCode.CART_INSUFFICIENT_STOCK, "재고가 부족합니다"));
+
+    // when & then
+    mockMvc.perform(put("/api/v1/carts/items/1")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("장바구니 아이템 제거 성공")
+  void removeCartItem_Success() throws Exception {
+    // when & then
+    mockMvc.perform(delete("/api/v1/carts/items/1")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.message").value("상품이 장바구니에서 제거되었습니다"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 장바구니 아이템 제거 실패")
+  void removeCartItem_ItemNotFound_Failure() throws Exception {
+    // given
+    willThrow(new CustomException(ErrorCode.CART_ITEM_NOT_FOUND, "장바구니 아이템을 찾을 수 없습니다"))
+        .given(cartService).removeCartItem(anyString(), anyLong());
+
+    // when & then
+    mockMvc.perform(delete("/api/v1/carts/items/999")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+        .andDo(print())
+        .andExpect(status().isNotFound());
+  }
+
+
+  @Test
+  @DisplayName("장바구니 비우기 성공")
+  void clearCart_Success() throws Exception {
+    // when & then
+    mockMvc.perform(delete("/api/v1/carts/items")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.message").value("장바구니가 비워졌습니다"));
+  }
+
+
+  @Test
+  @DisplayName("장바구니 요약 조회 성공")
+  void getCartSummary_Success() throws Exception {
+    // given
+    CartSummaryResponse summaryResponse = CartSummaryResponse.builder()
+        .totalItems(5)
+        .totalPrice(new BigDecimal("500000"))
+        .itemCount(3)
+        .build();
+
+    given(cartService.getCartSummary(BEARER_TOKEN)).willReturn(summaryResponse);
+
+    // when & then
+    mockMvc.perform(get("/api/v1/carts/summary")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.message").value("장바구니 요약 조회 성공"))
+        .andExpect(jsonPath("$.data.totalItems").value(5))
+        .andExpect(jsonPath("$.data.totalPrice").value(500000))
+        .andExpect(jsonPath("$.data.itemCount").value(3));
+  }
+
+  @Test
+  @DisplayName("장바구니 유효성 검증 성공 - 재고 부족 경고 포함")
+  void validateCart_WithStockWarning_Success() throws Exception {
+    // given
+    List<CartItemDto> items = new ArrayList<>();
+    items.add(CartItemDto.builder()
+        .cartItemId(1L)
+        .productId(1L)
+        .productName("빈티지 데님 셔츠")
+        .quantity(2)
+        .unitPrice(new BigDecimal("150000"))
+        .totalPrice(new BigDecimal("300000"))
+        .brand("리바이스")
+        .condition("VERY_GOOD")
+        .isStockAvailable(true)
+        .isPriceChanged(false)
+        .build());
+
+    items.add(CartItemDto.builder()
+        .cartItemId(2L)
+        .productId(2L)
+        .productName("재고 부족 상품")
+        .quantity(5)
+        .unitPrice(new BigDecimal("100000"))
+        .totalPrice(new BigDecimal("500000"))
+        .brand("테스트")
+        .condition("GOOD")
+        .isStockAvailable(false)
+        .isPriceChanged(false)
+        .warningMessage("재고가 부족합니다. 현재 재고: 2개, 요청 수량: 5개")
+        .build());
+
+    CartDto cartDto = CartDto.builder()
+        .cartId(1L)
+        .totalItems(7)
+        .totalPrice(new BigDecimal("800000"))
+        .itemCount(2)
+        .items(items)
+        .build();
+
+    given(cartService.validateCart(BEARER_TOKEN)).willReturn(cartDto);
+
+    // when & then
+    mockMvc.perform(post("/api/v1/carts/validate")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.message").value("장바구니 유효성 검증 완료"))
+        .andExpect(jsonPath("$.data.items").isArray())
+        .andExpect(jsonPath("$.data.items[0].isStockAvailable").value(true))
+        .andExpect(jsonPath("$.data.items[1].isStockAvailable").value(false))
+        .andExpect(
+            jsonPath("$.data.items[1].warningMessage").value("재고가 부족합니다. 현재 재고: 2개, 요청 수량: 5개"));
+  }
+
+  @Test
+  @DisplayName("다른 사용자의 장바구니 아이템 수량 변경 시도 - 403 Forbidden")
+  void updateCartItemQuantity_AccessDenied() throws Exception {
+    // given
+    UpdateQuantityRequest request = new UpdateQuantityRequest(3);
+
+    given(cartService.updateCartItemQuantity(anyString(), anyLong(), any(Integer.class)))
+        .willThrow(new CustomException(ErrorCode.CART_ACCESS_DENIED, "장바구니 접근 권한이 없습니다"));
+
+    // when & then
+    mockMvc.perform(put("/api/v1/carts/items/1")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value(403));
+  }
+
+  @Test
+  @DisplayName("재고 정보가 없는 상품 추가 시도 - 400 Bad Request")
+  void addCartItem_InvalidStock() throws Exception {
+    // given
+    CartItemRequest request = CartItemRequest.builder()
+        .productId(1L)
+        .quantity(1)
+        .build();
+
+    given(cartService.addCartItem(anyString(), any(CartItemRequest.class)))
+        .willThrow(new CustomException(ErrorCode.PRODUCT_INVALID_STOCK, "상품 재고 정보가 없습니다"));
+
+    // when & then
+    mockMvc.perform(post("/api/v1/carts/items")
+            .header(AUTHORIZATION_HEADER, BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400));
+  }
+}

--- a/backend/src/test/java/com/oboe/backend/cart/entity/CartItemTest.java
+++ b/backend/src/test/java/com/oboe/backend/cart/entity/CartItemTest.java
@@ -27,55 +27,27 @@ class CartItemTest {
   @BeforeEach
   void setUp() {
     // 테스트용 사용자 생성
-    user = User.builder()
-        .email("test@example.com")
-        .password("password123")
-        .name("홍길동")
-        .nickname("hong123")
-        .phoneNumber("010-1234-5678")
-        .role(UserRole.USER)
-        .status(UserStatus.ACTIVE)
-        .socialProvider(SocialProvider.LOCAL)
-        .build();
+    user = User.builder().email("test@example.com").password("password123").name("홍길동")
+        .nickname("hong123").phoneNumber("010-1234-5678").role(UserRole.USER)
+        .status(UserStatus.ACTIVE).socialProvider(SocialProvider.LOCAL).build();
 
     // 테스트용 상품 생성 (ID를 수동으로 설정)
-    product1 = Product.builder()
-        .name("빈티지 데님 셔츠")
-        .description("1980년대 빈티지 데님 셔츠")
-        .price(new BigDecimal("150000"))
-        .stockQuantity(5)
-        .productStatus(ProductStatus.ACTIVE)
-        .brand("리바이스")
-        .condition(Condition.VERY_GOOD)
-        .build();
+    product1 = Product.builder().name("빈티지 데님 셔츠").description("1980년대 빈티지 데님 셔츠")
+        .price(new BigDecimal("150000")).stockQuantity(5).productStatus(ProductStatus.ACTIVE)
+        .brand("리바이스").condition(Condition.VERY_GOOD).build();
     product1 = setIdForTest(product1, 1L); // 테스트용 ID 설정
 
-    product2 = Product.builder()
-        .name("빈티지 청바지")
-        .description("1990년대 빈티지 청바지")
-        .price(new BigDecimal("200000"))
-        .stockQuantity(3)
-        .productStatus(ProductStatus.ACTIVE)
-        .brand("리바이스")
-        .condition(Condition.EXCELLENT)
-        .build();
+    product2 = Product.builder().name("빈티지 청바지").description("1990년대 빈티지 청바지")
+        .price(new BigDecimal("200000")).stockQuantity(3).productStatus(ProductStatus.ACTIVE)
+        .brand("리바이스").condition(Condition.EXCELLENT).build();
     product2 = setIdForTest(product2, 2L); // 테스트용 ID 설정
 
     // 기본 테스트용 장바구니 생성
-    cart = Cart.builder()
-        .user(user)
-        .totalItems(0)
-        .totalPrice(BigDecimal.ZERO)
-        .isActive(true)
-        .build();
+    cart = Cart.builder().user(user).totalItems(0).totalPrice(BigDecimal.ZERO).build();
 
     // 기본 테스트용 장바구니 아이템 생성
-    cartItem = CartItem.builder()
-        .product(product1)
-        .quantity(2)
-        .unitPrice(product1.getPrice())
-        .totalPrice(product1.getPrice().multiply(BigDecimal.valueOf(2)))
-        .build();
+    cartItem = CartItem.builder().product(product1).quantity(2).unitPrice(product1.getPrice())
+        .totalPrice(product1.getPrice().multiply(BigDecimal.valueOf(2))).build();
   }
 
   // 테스트용 ID 설정을 위한 헬퍼 메서드
@@ -94,18 +66,16 @@ class CartItemTest {
   @DisplayName("CartItem 기본 생성 테스트")
   void createCartItem() {
     // given & when
-    CartItem newCartItem = CartItem.builder()
-        .product(product1)
-        .quantity(3)
+    CartItem newCartItem = CartItem.builder().product(product1).quantity(3)
         .unitPrice(product1.getPrice())
-        .totalPrice(product1.getPrice().multiply(BigDecimal.valueOf(3)))
-        .build();
+        .totalPrice(product1.getPrice().multiply(BigDecimal.valueOf(3))).build();
 
     // then
     assertThat(newCartItem.getProduct()).isEqualTo(product1);
     assertThat(newCartItem.getQuantity()).isEqualTo(3);
     assertThat(newCartItem.getUnitPrice()).isEqualByComparingTo(product1.getPrice());
-    assertThat(newCartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("450000")); // 150000 * 3
+    assertThat(newCartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("450000")); // 150000 * 3
   }
 
   @Test
@@ -119,24 +89,22 @@ class CartItemTest {
 
     // then
     assertThat(cartItem.getQuantity()).isEqualTo(5); // 2 + 3
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("750000")); // 150000 * 5
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("750000")); // 150000 * 5
   }
 
   @Test
   @DisplayName("수량 증가 테스트 - 잘못된 수량")
   void increaseQuantity_InvalidQuantity() {
     // given & when & then
-    assertThatThrownBy(() -> cartItem.increaseQuantity(0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("추가할 수량은 0보다 커야 합니다");
+    assertThatThrownBy(() -> cartItem.increaseQuantity(0)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("추가할 수량은 0보다 커야 합니다");
 
-    assertThatThrownBy(() -> cartItem.increaseQuantity(-1))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("추가할 수량은 0보다 커야 합니다");
+    assertThatThrownBy(() -> cartItem.increaseQuantity(-1)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("추가할 수량은 0보다 커야 합니다");
 
-    assertThatThrownBy(() -> cartItem.increaseQuantity(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("추가할 수량은 0보다 커야 합니다");
+    assertThatThrownBy(() -> cartItem.increaseQuantity(null)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("추가할 수량은 0보다 커야 합니다");
   }
 
   @Test
@@ -150,24 +118,22 @@ class CartItemTest {
 
     // then
     assertThat(cartItem.getQuantity()).isEqualTo(1); // 2 - 1
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("150000")); // 150000 * 1
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("150000")); // 150000 * 1
   }
 
   @Test
   @DisplayName("수량 감소 테스트 - 잘못된 수량")
   void decreaseQuantity_InvalidQuantity() {
     // given & when & then
-    assertThatThrownBy(() -> cartItem.decreaseQuantity(0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("감소할 수량은 0보다 커야 합니다");
+    assertThatThrownBy(() -> cartItem.decreaseQuantity(0)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("감소할 수량은 0보다 커야 합니다");
 
-    assertThatThrownBy(() -> cartItem.decreaseQuantity(-1))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("감소할 수량은 0보다 커야 합니다");
+    assertThatThrownBy(() -> cartItem.decreaseQuantity(-1)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("감소할 수량은 0보다 커야 합니다");
 
-    assertThatThrownBy(() -> cartItem.decreaseQuantity(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("감소할 수량은 0보다 커야 합니다");
+    assertThatThrownBy(() -> cartItem.decreaseQuantity(null)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("감소할 수량은 0보다 커야 합니다");
   }
 
   @Test
@@ -177,9 +143,8 @@ class CartItemTest {
     Integer decreaseQuantity = 5; // 현재 수량은 2
 
     // when & then
-    assertThatThrownBy(() -> cartItem.decreaseQuantity(decreaseQuantity))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("수량이 부족합니다");
+    assertThatThrownBy(() -> cartItem.decreaseQuantity(decreaseQuantity)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("수량이 부족합니다");
   }
 
   @Test
@@ -193,24 +158,22 @@ class CartItemTest {
 
     // then
     assertThat(cartItem.getQuantity()).isEqualTo(5);
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("750000")); // 150000 * 5
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("750000")); // 150000 * 5
   }
 
   @Test
   @DisplayName("수량 설정 테스트 - 잘못된 수량")
   void setQuantity_InvalidQuantity() {
     // given & when & then
-    assertThatThrownBy(() -> cartItem.setQuantity(0))
-        .isInstanceOf(IllegalArgumentException.class)
+    assertThatThrownBy(() -> cartItem.setQuantity(0)).isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("수량은 0보다 커야 합니다");
 
-    assertThatThrownBy(() -> cartItem.setQuantity(-1))
-        .isInstanceOf(IllegalArgumentException.class)
+    assertThatThrownBy(() -> cartItem.setQuantity(-1)).isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("수량은 0보다 커야 합니다");
 
-    assertThatThrownBy(() -> cartItem.setQuantity(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("수량은 0보다 커야 합니다");
+    assertThatThrownBy(() -> cartItem.setQuantity(null)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("수량은 0보다 커야 합니다");
   }
 
   @Test
@@ -224,20 +187,19 @@ class CartItemTest {
 
     // then
     assertThat(cartItem.getUnitPrice()).isEqualByComparingTo(newUnitPrice);
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("360000")); // 180000 * 2
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("360000")); // 180000 * 2
   }
 
   @Test
   @DisplayName("단위 가격 설정 테스트 - 잘못된 가격")
   void setUnitPrice_InvalidPrice() {
     // given & when & then
-    assertThatThrownBy(() -> cartItem.setUnitPrice(BigDecimal.valueOf(-1)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("단위 가격은 0 이상이어야 합니다");
+    assertThatThrownBy(() -> cartItem.setUnitPrice(BigDecimal.valueOf(-1))).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("단위 가격은 0 이상이어야 합니다");
 
-    assertThatThrownBy(() -> cartItem.setUnitPrice(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("단위 가격은 0 이상이어야 합니다");
+    assertThatThrownBy(() -> cartItem.setUnitPrice(null)).isInstanceOf(
+        IllegalArgumentException.class).hasMessageContaining("단위 가격은 0 이상이어야 합니다");
   }
 
   @Test
@@ -251,7 +213,8 @@ class CartItemTest {
 
     // then
     assertThat(cartItem.getUnitPrice()).isEqualByComparingTo(product1.getPrice()); // 150000
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("300000")); // 150000 * 2
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("300000")); // 150000 * 2
   }
 
   @Test
@@ -463,14 +426,17 @@ class CartItemTest {
     cartItem.setQuantity(5);
 
     // when & then
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("500000")); // 100000 * 5
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("500000")); // 100000 * 5
 
     // 수량 변경 시 자동 재계산
     cartItem.setQuantity(3);
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("300000")); // 100000 * 3
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("300000")); // 100000 * 3
 
     // 단위 가격 변경 시 자동 재계산
     cartItem.setUnitPrice(new BigDecimal("150000"));
-    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(new BigDecimal("450000")); // 150000 * 3
+    assertThat(cartItem.getTotalPrice()).isEqualByComparingTo(
+        new BigDecimal("450000")); // 150000 * 3
   }
 }

--- a/backend/src/test/java/com/oboe/backend/cart/entity/CartTest.java
+++ b/backend/src/test/java/com/oboe/backend/cart/entity/CartTest.java
@@ -1,7 +1,6 @@
 package com.oboe.backend.cart.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.oboe.backend.product.entity.Condition;
 import com.oboe.backend.product.entity.Product;
@@ -11,8 +10,6 @@ import com.oboe.backend.user.entity.User;
 import com.oboe.backend.user.entity.UserRole;
 import com.oboe.backend.user.entity.UserStatus;
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -67,7 +64,6 @@ class CartTest {
         .user(user)
         .totalItems(0)
         .totalPrice(BigDecimal.ZERO)
-        .isActive(true)
         .build();
   }
 
@@ -91,14 +87,12 @@ class CartTest {
         .user(user)
         .totalItems(0)
         .totalPrice(BigDecimal.ZERO)
-        .isActive(true)
         .build();
 
     // then
     assertThat(newCart.getUser()).isEqualTo(user);
     assertThat(newCart.getTotalItems()).isEqualTo(0);
     assertThat(newCart.getTotalPrice()).isEqualByComparingTo(BigDecimal.ZERO);
-    assertThat(newCart.getIsActive()).isTrue();
     assertThat(newCart.getCartItems()).isEmpty();
   }
 
@@ -264,26 +258,19 @@ class CartTest {
   }
 
   @Test
-  @DisplayName("장바구니 비활성화 테스트")
-  void deactivate() {
-    // given & when
-    cart.deactivate();
+  @DisplayName("장바구니 비우기 테스트")
+  void clearCart() {
+    // given - 상품 추가
+    cart.addCartItem(createCartItem(product1, 2));
+    assertThat(cart.getTotalItems()).isEqualTo(2);
 
-    // then
-    assertThat(cart.getIsActive()).isFalse();
-  }
+    // when - 장바구니 비우기
+    cart.clear();
 
-  @Test
-  @DisplayName("장바구니 활성화 테스트")
-  void activate() {
-    // given
-    cart.deactivate();
-
-    // when
-    cart.activate();
-
-    // then
-    assertThat(cart.getIsActive()).isTrue();
+    // then - 장바구니가 비워짐
+    assertThat(cart.isEmpty()).isTrue();
+    assertThat(cart.getTotalItems()).isEqualTo(0);
+    assertThat(cart.getTotalPrice()).isEqualByComparingTo(BigDecimal.ZERO);
   }
 
   @Test
@@ -404,23 +391,6 @@ class CartTest {
   }
 
   @Test
-  @DisplayName("주문 가능 여부 확인 테스트 - 장바구니 비활성화")
-  void canPlaceOrder_InactiveCart() {
-    // given
-    CartItem cartItem = CartItem.builder()
-        .product(product1)
-        .quantity(1)
-        .unitPrice(product1.getPrice())
-        .totalPrice(product1.getPrice())
-        .build();
-    cart.addCartItem(cartItem);
-    cart.deactivate();
-
-    // when & then
-    assertThat(cart.canPlaceOrder()).isFalse();
-  }
-
-  @Test
   @DisplayName("다양한 상품이 포함된 장바구니 총액 계산 테스트")
   void calculateTotalPrice_MultipleProducts() {
     // given
@@ -461,10 +431,19 @@ class CartTest {
     assertThat(cart.getUser()).isEqualTo(user);
     assertThat(cart.getTotalItems()).isEqualTo(0);
     assertThat(cart.getTotalPrice()).isEqualByComparingTo(BigDecimal.ZERO);
-    assertThat(cart.getIsActive()).isTrue();
     assertThat(cart.getCartItems()).isEmpty();
     assertThat(cart.isEmpty()).isTrue();
     assertThat(cart.getItemCount()).isEqualTo(0);
     assertThat(cart.canPlaceOrder()).isFalse();
+  }
+
+  private CartItem createCartItem(Product product, int quantity) {
+    return CartItem.builder()
+        .cart(cart)
+        .product(product)
+        .quantity(quantity)
+        .unitPrice(product.getPrice())
+        .totalPrice(product.getPrice().multiply(BigDecimal.valueOf(quantity)))
+        .build();
   }
 }

--- a/backend/src/test/java/com/oboe/backend/cart/integration/CartIntegrationTest.java
+++ b/backend/src/test/java/com/oboe/backend/cart/integration/CartIntegrationTest.java
@@ -1,0 +1,597 @@
+package com.oboe.backend.cart.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oboe.backend.cart.dto.request.CartItemRequest;
+import com.oboe.backend.cart.dto.request.UpdateQuantityRequest;
+import com.oboe.backend.cart.entity.Cart;
+import com.oboe.backend.cart.entity.CartItem;
+import com.oboe.backend.cart.repository.CartItemRepository;
+import com.oboe.backend.cart.repository.CartRepository;
+import com.oboe.backend.common.service.TokenProcessor;
+import com.oboe.backend.product.entity.Condition;
+import com.oboe.backend.product.entity.Product;
+import com.oboe.backend.product.entity.ProductStatus;
+import com.oboe.backend.product.repository.ProductRepository;
+import com.oboe.backend.user.entity.SocialProvider;
+import com.oboe.backend.user.entity.User;
+import com.oboe.backend.user.entity.UserRole;
+import com.oboe.backend.user.entity.UserStatus;
+import com.oboe.backend.user.repository.UserRepository;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Cart Integration 테스트")
+class CartIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private ProductRepository productRepository;
+
+  @Autowired
+  private CartRepository cartRepository;
+
+  @Autowired
+  private CartItemRepository cartItemRepository;
+
+  @MockBean
+  private TokenProcessor tokenProcessor;
+
+  private User testUser;
+  private Product testProduct;
+  private Product outOfStockProduct;
+  private String bearerToken;
+
+  @BeforeEach
+  void setUp() {
+    // 데이터 초기화
+    cartItemRepository.deleteAll();
+    cartRepository.deleteAll();
+    productRepository.deleteAll();
+    userRepository.deleteAll();
+
+    // 테스트용 사용자 생성
+    testUser = User.builder()
+        .email("test@example.com")
+        .password("password123")
+        .name("홍길동")
+        .nickname("hong123")
+        .phoneNumber("010-1234-5678")
+        .role(UserRole.USER)
+        .status(UserStatus.ACTIVE)
+        .socialProvider(SocialProvider.LOCAL)
+        .build();
+    testUser = userRepository.save(testUser);
+
+    // 테스트용 상품 생성 (재고 충분)
+    testProduct = Product.builder()
+        .name("빈티지 데님 셔츠")
+        .description("1980년대 빈티지 데님 셔츠")
+        .price(new BigDecimal("150000"))
+        .stockQuantity(10)
+        .productStatus(ProductStatus.ACTIVE)
+        .brand("리바이스")
+        .condition(Condition.VERY_GOOD)
+        .build();
+    testProduct = productRepository.save(testProduct);
+
+    // 재고 부족 상품
+    outOfStockProduct = Product.builder()
+        .name("품절 상품")
+        .description("재고가 부족한 상품")
+        .price(new BigDecimal("100000"))
+        .stockQuantity(2)
+        .productStatus(ProductStatus.ACTIVE)
+        .brand("테스트")
+        .condition(Condition.GOOD)
+        .build();
+    outOfStockProduct = productRepository.save(outOfStockProduct);
+
+    bearerToken = "Bearer test-token";
+
+    // TokenProcessor Mock 설정 - 더 구체적으로
+    org.mockito.BDDMockito.given(tokenProcessor.extractEmailFromBearerToken(
+            org.mockito.ArgumentMatchers.eq(bearerToken),
+            org.mockito.ArgumentMatchers.anyString()))
+        .willReturn(testUser.getEmail());
+
+    // 모든 가능한 호출에 대해 Mock 설정
+    org.mockito.BDDMockito.given(tokenProcessor.extractEmailFromBearerToken(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString()))
+        .willReturn(testUser.getEmail());
+  }
+
+  @Nested
+  @DisplayName("실제 HTTP API 통합 테스트")
+  class HttpApiIntegrationTests {
+
+    @Test
+    @DisplayName("장바구니 전체 플로우: HTTP API → Service → Repository → Database")
+    void fullCartWorkflowViaHttpApi() throws Exception {
+      // 1. 빈 장바구니 조회 (GET /api/carts)
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.code").value(200))
+          .andExpect(jsonPath("$.data.totalItems").value(0))
+          .andExpect(jsonPath("$.data.items").isEmpty());
+
+      // 2. 상품 추가 (POST /api/carts/items)
+      CartItemRequest addRequest = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(3)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(addRequest)))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.code").value(200))
+          .andExpect(jsonPath("$.data.quantity").value(3))
+          .andExpect(jsonPath("$.data.totalPrice").value(450000));
+
+      // 3. 장바구니 조회 (상품 추가 후)
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.totalItems").value(3))
+          .andExpect(jsonPath("$.data.items").isArray())
+          .andExpect(jsonPath("$.data.items[0].quantity").value(3));
+
+      // 4. 데이터베이스에서 직접 확인
+      Cart savedCart = cartRepository.findByUserId(testUser.getId()).orElseThrow();
+      assertThat(savedCart.getCartItems()).hasSize(1);
+      assertThat(savedCart.getTotalItems()).isEqualTo(3);
+
+      // 5. 수량 변경 (PUT /api/carts/items/{id})
+      CartItem cartItem = savedCart.getCartItems().get(0);
+      UpdateQuantityRequest updateRequest = new UpdateQuantityRequest(7);
+
+      mockMvc.perform(put("/api/v1/carts/items/" + cartItem.getId())
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(updateRequest)))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.quantity").value(7))
+          .andExpect(jsonPath("$.data.totalPrice").value(1050000)); // 150000 * 7
+
+      // 6. 아이템 제거 (DELETE /api/carts/items/{id})
+      mockMvc.perform(delete("/api/v1/carts/items/" + cartItem.getId())
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.code").value(200));
+
+      // 7. 장바구니 조회 (아이템 제거 후)
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.totalItems").value(0))
+          .andExpect(jsonPath("$.data.items").isEmpty());
+    }
+
+    @Test
+    @DisplayName("재고 검증 API 통합 테스트")
+    void stockValidationApiIntegration() throws Exception {
+      // 1. 정상 상품 추가 (재고 10개 중 5개)
+      CartItemRequest normalRequest = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(5)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(normalRequest)))
+          .andExpect(status().isOk());
+
+      // 2. 같은 상품 추가로 재고 초과 시도 (409 Conflict 응답)
+      CartItemRequest overStockRequest = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(6) // 기존 5개 + 새로 6개 = 11개, 재고는 10개
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(overStockRequest)))
+          .andDo(print())
+          .andExpect(status().isConflict())
+          .andExpect(jsonPath("$.code").value(409));
+
+      // 3. 재고 부족 상품 추가 시도 (409 Conflict 응답)
+      CartItemRequest insufficientRequest = CartItemRequest.builder()
+          .productId(outOfStockProduct.getId())
+          .quantity(5) // 재고 2개인데 5개 요청
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(insufficientRequest)))
+          .andDo(print())
+          .andExpect(status().isConflict());
+
+      // 4. 장바구니 상태 확인 (정상 상품만 들어있어야 함)
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.totalItems").value(5))
+          .andExpect(jsonPath("$.data.items").isArray())
+          .andExpect(jsonPath("$.data.items[0].productId").value(testProduct.getId()));
+    }
+
+    @Test
+    @DisplayName("장바구니 유효성 검증 API 통합 테스트")
+    void cartValidationApiIntegration() throws Exception {
+      // 1. 상품을 장바구니에 추가
+      CartItemRequest addRequest = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(5)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(addRequest)))
+          .andExpect(status().isOk());
+
+      // 2. 상품 재고를 인위적으로 줄임 (10개 → 3개)
+      setStockQuantityForTest(testProduct, 3);
+      testProduct = productRepository.save(testProduct);
+      productRepository.flush(); // 강제로 DB에 반영
+
+      // 3. 장바구니 유효성 검증 API 호출 (POST /api/carts/validate)
+      mockMvc.perform(post("/api/v1/carts/validate")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.code").value(200))
+          .andExpect(jsonPath("$.data.items[0].isStockAvailable").value(false))
+          .andExpect(jsonPath("$.data.items[0].warningMessage").exists());
+
+      // 4. 데이터베이스에서 직접 확인
+      Cart cart = cartRepository.findByUserId(testUser.getId()).orElseThrow();
+      CartItem cartItem = cart.getCartItems().get(0);
+      assertThat(cartItem.getQuantity()).isEqualTo(5);
+      assertThat(cartItem.getProduct().getStockQuantity()).isEqualTo(3);
+      assertThat(cartItem.isStockAvailable()).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("API 에러 응답 통합 테스트")
+  class ApiErrorIntegrationTests {
+
+    @Test
+    @DisplayName("존재하지 않는 상품 추가 시 404 응답")
+    void addNonExistentProduct_Returns404() throws Exception {
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(999L)
+          .quantity(1)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andDo(print())
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value(404));
+    }
+
+    @Test
+    @DisplayName("재고 부족 상품 추가 시 409 응답")
+    void addInsufficientStockProduct_Returns409() throws Exception {
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(outOfStockProduct.getId())
+          .quantity(10) // 재고 2개인데 10개 요청
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andDo(print())
+          .andExpect(status().isConflict())
+          .andExpect(jsonPath("$.code").value(409));
+    }
+
+    @Test
+    @DisplayName("잘못된 수량으로 상품 추가 시 400 응답")
+    void addInvalidQuantityProduct_Returns400() throws Exception {
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(-1) // 음수 수량
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andDo(print())
+          .andExpect(status().isBadRequest());
+    }
+  }
+
+  @Nested
+  @DisplayName("부족한 테스트 케이스 추가")
+  class MissingTestCases {
+
+    @Test
+    @DisplayName("장바구니 요약 API 테스트")
+    void getCartSummary_IntegrationTest() throws Exception {
+      // 1. 여러 상품을 장바구니에 추가
+      CartItemRequest request1 = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(3)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request1)))
+          .andExpect(status().isOk());
+
+      CartItemRequest request2 = CartItemRequest.builder()
+          .productId(outOfStockProduct.getId())
+          .quantity(1)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request2)))
+          .andExpect(status().isOk());
+
+      // 2. 장바구니 요약 조회 (GET /api/v1/carts/summary)
+      mockMvc.perform(get("/api/v1/carts/summary")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.code").value(200))
+          .andExpect(jsonPath("$.data.totalItems").value(4)) // 3 + 1
+          .andExpect(jsonPath("$.data.totalPrice").value(550000)) // (150000*3) + (100000*1)
+          .andExpect(jsonPath("$.data.itemCount").value(2));
+    }
+
+    @Test
+    @DisplayName("대량 수량 변경 테스트 - 경계값")
+    void updateQuantity_LargeAmount() throws Exception {
+      // 1. 상품 추가
+      CartItemRequest addRequest = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(1)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(addRequest)))
+          .andExpect(status().isOk());
+
+      // 2. CartItem ID 조회
+      Cart cart = cartRepository.findByUserId(testUser.getId()).orElseThrow();
+      CartItem cartItem = cart.getCartItems().get(0);
+
+      // 3. 재고 한계까지 수량 변경 (재고 10개)
+      UpdateQuantityRequest updateRequest = new UpdateQuantityRequest(10);
+
+      mockMvc.perform(put("/api/v1/carts/items/" + cartItem.getId())
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(updateRequest)))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.quantity").value(10))
+          .andExpect(jsonPath("$.data.totalPrice").value(1500000)); // 150000 * 10
+    }
+
+    @Test
+    @DisplayName("연속된 상품 추가 및 제거 테스트")
+    void continuousAddAndRemove() throws Exception {
+      // 1. 첫 번째 상품 추가
+      CartItemRequest request1 = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(2)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request1)))
+          .andExpect(status().isOk());
+
+      // 2. 두 번째 상품 추가
+      CartItemRequest request2 = CartItemRequest.builder()
+          .productId(outOfStockProduct.getId())
+          .quantity(1)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request2)))
+          .andExpect(status().isOk());
+
+      // 3. 장바구니 확인 (2개 아이템)
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.itemCount").value(2));
+
+      // 4. 첫 번째 아이템 제거
+      Cart cart = cartRepository.findByUserId(testUser.getId()).orElseThrow();
+      CartItem firstItem = cart.getCartItems().stream()
+          .filter(item -> item.getProduct().getId().equals(testProduct.getId()))
+          .findFirst().orElseThrow();
+
+      mockMvc.perform(delete("/api/v1/carts/items/" + firstItem.getId())
+              .header("Authorization", bearerToken))
+          .andExpect(status().isOk());
+
+      // 5. 장바구니 확인 (1개 아이템 남음)
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.itemCount").value(1))
+          .andExpect(jsonPath("$.data.totalItems").value(1));
+    }
+
+    @Test
+    @DisplayName("빈 장바구니 요약 조회 테스트")
+    void getCartSummary_EmptyCart() throws Exception {
+      // 빈 장바구니 요약 조회
+      mockMvc.perform(get("/api/v1/carts/summary")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.code").value(200))
+          .andExpect(jsonPath("$.data.totalItems").value(0))
+          .andExpect(jsonPath("$.data.totalPrice").value(0))
+          .andExpect(jsonPath("$.data.itemCount").value(0));
+    }
+  }
+
+  @Nested
+  @DisplayName("데이터 일관성 통합 테스트")
+  class DataConsistencyIntegrationTests {
+
+    @Test
+    @DisplayName("HTTP API를 통한 장바구니 총액 계산 일관성")
+    void cartTotalPriceConsistencyViaApi() throws Exception {
+      // 1. 첫 번째 상품 추가
+      CartItemRequest request1 = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(3)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request1)))
+          .andExpect(status().isOk());
+
+      // 2. 두 번째 상품 추가
+      CartItemRequest request2 = CartItemRequest.builder()
+          .productId(outOfStockProduct.getId())
+          .quantity(2)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request2)))
+          .andExpect(status().isOk());
+
+      // 3. 장바구니 조회로 총액 확인
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.totalItems").value(5))
+          .andExpect(jsonPath("$.data.totalPrice").value(650000)); // (150000*3) + (100000*2)
+
+      // 4. 데이터베이스에서 직접 확인
+      Cart savedCart = cartRepository.findByUserId(testUser.getId()).orElseThrow();
+      assertThat(savedCart.getTotalItems()).isEqualTo(5);
+      assertThat(savedCart.getTotalPrice()).isEqualByComparingTo(new BigDecimal("650000"));
+      assertThat(savedCart.getCartItems()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("수량 변경 후 총액 재계산 HTTP API 통합")
+    void quantityUpdateRecalculationViaApi() throws Exception {
+      // 1. 상품 추가
+      CartItemRequest addRequest = CartItemRequest.builder()
+          .productId(testProduct.getId())
+          .quantity(2)
+          .build();
+
+      mockMvc.perform(post("/api/v1/carts/items")
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(addRequest)))
+          .andExpect(status().isOk());
+
+      // 2. 데이터베이스에서 CartItem ID 조회
+      cartRepository.flush();
+      Cart cart = cartRepository.findByUserId(testUser.getId()).orElseThrow();
+      CartItem cartItem = cart.getCartItems().get(0);
+
+      // 3. 수량 변경 API 호출
+      UpdateQuantityRequest updateRequest = new UpdateQuantityRequest(8);
+
+      mockMvc.perform(put("/api/v1/carts/items/" + cartItem.getId())
+              .header("Authorization", bearerToken)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(updateRequest)))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.quantity").value(8))
+          .andExpect(jsonPath("$.data.totalPrice").value(1200000)); // 150000 * 8
+
+      // 4. 장바구니 전체 조회로 총액 확인
+      mockMvc.perform(get("/api/v1/carts")
+              .header("Authorization", bearerToken))
+          .andDo(print())
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.totalItems").value(8))
+          .andExpect(jsonPath("$.data.totalPrice").value(1200000));
+
+      // 5. 데이터베이스 일관성 확인
+      Cart updatedCart = cartRepository.findByUserId(testUser.getId()).orElseThrow();
+      assertThat(updatedCart.getTotalItems()).isEqualTo(8);
+      assertThat(updatedCart.getTotalPrice()).isEqualByComparingTo(new BigDecimal("1200000"));
+    }
+  }
+
+  private void setStockQuantityForTest(Product product, Integer stockQuantity) {
+    try {
+      java.lang.reflect.Field stockQuantityField = Product.class.getDeclaredField("stockQuantity");
+      stockQuantityField.setAccessible(true);
+      stockQuantityField.set(product, stockQuantity);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set stock quantity for test", e);
+    }
+  }
+}

--- a/backend/src/test/java/com/oboe/backend/cart/repository/CartRepositoryTest.java
+++ b/backend/src/test/java/com/oboe/backend/cart/repository/CartRepositoryTest.java
@@ -1,0 +1,221 @@
+package com.oboe.backend.cart.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.oboe.backend.cart.entity.Cart;
+import com.oboe.backend.cart.repository.CartRepository;
+import com.oboe.backend.user.entity.SocialProvider;
+import com.oboe.backend.user.entity.User;
+import com.oboe.backend.user.entity.UserRole;
+import com.oboe.backend.user.entity.UserStatus;
+import com.oboe.backend.user.repository.UserRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Cart Repository 테스트")
+class CartRepositoryTest {
+
+  @Autowired
+  private CartRepository cartRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  private User user;
+  private Cart cart;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 데이터 초기화
+    cartRepository.deleteAll();
+    userRepository.deleteAll();
+
+    // 테스트용 사용자 생성 및 저장
+    user = User.builder()
+        .email("test@example.com")
+        .password("password123")
+        .name("홍길동")
+        .nickname("hong123")
+        .phoneNumber("010-1234-5678")
+        .role(UserRole.USER)
+        .status(UserStatus.ACTIVE)
+        .socialProvider(SocialProvider.LOCAL)
+        .build();
+    user = userRepository.save(user);
+
+    // 테스트용 장바구니 생성 및 저장
+    cart = Cart.builder()
+        .user(user)
+        .totalItems(0)
+        .totalPrice(BigDecimal.ZERO)
+        .build();
+    cart = cartRepository.save(cart);
+  }
+
+  @Test
+  @DisplayName("사용자 ID로 장바구니 조회 테스트")
+  void findByUserId() {
+    // when
+    Optional<Cart> foundCart = cartRepository.findByUserId(user.getId());
+
+    // then
+    assertThat(foundCart).isPresent();
+    assertThat(foundCart.get().getUser()).isEqualTo(user);
+  }
+
+  @Test
+  @DisplayName("사용자로 장바구니 조회 테스트")
+  void findByUser() {
+    // when
+    Optional<Cart> foundCart = cartRepository.findByUser(user);
+
+    // then
+    assertThat(foundCart).isPresent();
+    assertThat(foundCart.get()).isEqualTo(cart);
+  }
+
+  @Test
+  @DisplayName("사용자의 장바구니 존재 여부 확인 테스트")
+  void existsByUser() {
+    // when
+    boolean exists = cartRepository.existsByUser(user);
+
+    // then
+    assertThat(exists).isTrue();
+  }
+
+  @Test
+  @DisplayName("장바구니 저장 및 조회 테스트")
+  void saveAndFindCart() {
+    // given
+    User newUser = User.builder()
+        .email("new@example.com")
+        .password("password123")
+        .name("김철수")
+        .nickname("kim123")
+        .phoneNumber("010-9876-5432")
+        .role(UserRole.USER)
+        .status(UserStatus.ACTIVE)
+        .socialProvider(SocialProvider.LOCAL)
+        .build();
+
+    Cart newCart = Cart.builder()
+        .user(newUser)
+        .totalItems(2)
+        .totalPrice(new BigDecimal("300000"))
+        .build();
+
+    newUser = userRepository.save(newUser);
+
+    // when
+    Cart savedCart = cartRepository.save(newCart);
+
+    Cart foundCart = cartRepository.findById(savedCart.getId()).orElse(null);
+
+    // then
+    assertThat(foundCart).isNotNull();
+    assertThat(foundCart.getUser()).isEqualTo(newUser);
+    assertThat(foundCart.getTotalItems()).isEqualTo(2);
+    assertThat(foundCart.getTotalPrice()).isEqualByComparingTo(new BigDecimal("300000"));
+  }
+
+  @Test
+  @DisplayName("모든 장바구니 조회 테스트")
+  void findAllCarts() {
+    // when
+    var allCarts = cartRepository.findAll();
+
+    // then
+    assertThat(allCarts).hasSize(1);
+    assertThat(allCarts).contains(cart);
+  }
+
+  @Test
+  @DisplayName("장바구니 ID로 조회 테스트")
+  void findById() {
+    // when
+    Optional<Cart> foundCart = cartRepository.findById(cart.getId());
+
+    // then
+    assertThat(foundCart).isPresent();
+    assertThat(foundCart.get()).isEqualTo(cart);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 ID로 조회 테스트")
+  void findById_NonExistent() {
+    // when
+    Optional<Cart> foundCart = cartRepository.findById(999L);
+
+    // then
+    assertThat(foundCart).isEmpty();
+  }
+
+  @Test
+  @DisplayName("장바구니 삭제 테스트")
+  void deleteCart() {
+    // given
+    Long cartId = cart.getId();
+
+    // when
+    cartRepository.deleteById(cartId);
+
+    // then
+    assertThat(cartRepository.findById(cartId)).isEmpty();
+    assertThat(cartRepository.findAll()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("장바구니 조회 테스트")
+  void findByUserId_Success() {
+    // when - 사용자 장바구니 조회
+    Optional<Cart> foundCart = cartRepository.findByUserId(user.getId());
+
+    // then - 장바구니가 조회됨
+    assertThat(foundCart).isPresent();
+    assertThat(foundCart.get().getUser()).isEqualTo(user);
+    assertThat(foundCart.get().getTotalItems()).isEqualTo(0);
+    assertThat(foundCart.get().getTotalPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자 ID로 장바구니 조회")
+  void findByUserId_NonExistentUser() {
+    // when
+    Optional<Cart> foundCart = cartRepository.findByUserId(999L);
+
+    // then
+    assertThat(foundCart).isEmpty();
+  }
+
+  @Test
+  @DisplayName("장바구니 업데이트 테스트")
+  void updateCart() {
+    // given - 기존 장바구니 확인
+    assertThat(cart.getTotalItems()).isEqualTo(0);
+    assertThat(cart.getTotalPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+    
+    // when - 장바구니 비우기 (clear 메서드 테스트)
+    cart.clear();
+    Cart updatedCart = cartRepository.save(cart);
+
+    // then - 장바구니가 비워졌는지 확인
+    assertThat(updatedCart.isEmpty()).isTrue();
+    assertThat(updatedCart.getTotalItems()).isEqualTo(0);
+    assertThat(updatedCart.getTotalPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+    assertThat(updatedCart.getUser()).isEqualTo(user);
+    assertThat(updatedCart.getId()).isEqualTo(cart.getId());
+  }
+
+}

--- a/backend/src/test/java/com/oboe/backend/cart/service/CartServiceTest.java
+++ b/backend/src/test/java/com/oboe/backend/cart/service/CartServiceTest.java
@@ -1,0 +1,741 @@
+package com.oboe.backend.cart.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.oboe.backend.cart.dto.CartDto;
+import com.oboe.backend.cart.dto.CartItemDto;
+import com.oboe.backend.cart.dto.request.CartItemRequest;
+import com.oboe.backend.cart.dto.response.CartSummaryResponse;
+import com.oboe.backend.cart.entity.Cart;
+import com.oboe.backend.cart.entity.CartItem;
+import com.oboe.backend.cart.repository.CartItemRepository;
+import com.oboe.backend.cart.repository.CartRepository;
+import com.oboe.backend.common.exception.CustomException;
+import com.oboe.backend.common.exception.ErrorCode;
+import com.oboe.backend.common.service.TokenProcessor;
+import com.oboe.backend.product.entity.Condition;
+import com.oboe.backend.product.entity.Product;
+import com.oboe.backend.product.entity.ProductStatus;
+import com.oboe.backend.product.repository.ProductRepository;
+import com.oboe.backend.user.entity.SocialProvider;
+import com.oboe.backend.user.entity.User;
+import com.oboe.backend.user.entity.UserRole;
+import com.oboe.backend.user.entity.UserStatus;
+import com.oboe.backend.user.repository.UserRepository;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CartService 테스트")
+class CartServiceTest {
+
+  @Mock
+  private CartRepository cartRepository;
+
+  @Mock
+  private CartItemRepository cartItemRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private TokenProcessor tokenProcessor;
+
+  @InjectMocks
+  private CartService cartService;
+
+  private User testUser;
+  private Product testProduct;
+  private Product outOfStockProduct;
+  private Product inactiveProduct;
+  private Cart testCart;
+  private CartItem testCartItem;
+  private CartItemRequest cartItemRequest;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트용 사용자 생성
+    testUser = User.builder()
+        .email("test@example.com")
+        .password("password123")
+        .name("홍길동")
+        .nickname("hong123")
+        .phoneNumber("010-1234-5678")
+        .role(UserRole.USER)
+        .status(UserStatus.ACTIVE)
+        .socialProvider(SocialProvider.LOCAL)
+        .build();
+    setIdForTest(testUser, 1L);
+
+    // 테스트용 상품 생성 (재고 충분)
+    testProduct = Product.builder()
+        .name("빈티지 데님 셔츠")
+        .description("1980년대 빈티지 데님 셔츠")
+        .price(new BigDecimal("150000"))
+        .stockQuantity(10)
+        .productStatus(ProductStatus.ACTIVE)
+        .brand("리바이스")
+        .condition(Condition.VERY_GOOD)
+        .build();
+    setIdForTest(testProduct, 1L);
+
+    // 재고 부족 상품
+    outOfStockProduct = Product.builder()
+        .name("품절 상품")
+        .description("재고가 부족한 상품")
+        .price(new BigDecimal("100000"))
+        .stockQuantity(2)
+        .productStatus(ProductStatus.ACTIVE)
+        .brand("테스트")
+        .condition(Condition.GOOD)
+        .build();
+    setIdForTest(outOfStockProduct, 2L);
+
+    // 비활성 상품
+    inactiveProduct = Product.builder()
+        .name("비활성 상품")
+        .description("판매 중지된 상품")
+        .price(new BigDecimal("200000"))
+        .stockQuantity(5)
+        .productStatus(ProductStatus.INACTIVE)
+        .brand("테스트")
+        .condition(Condition.EXCELLENT)
+        .build();
+    setIdForTest(inactiveProduct, 3L);
+
+    // 테스트용 장바구니 생성
+    testCart = Cart.builder()
+        .user(testUser)
+        .totalItems(0)
+        .totalPrice(BigDecimal.ZERO)
+        .build();
+    setIdForTest(testCart, 1L);
+
+    // 테스트용 장바구니 아이템 생성
+    testCartItem = CartItem.builder()
+        .cart(testCart)
+        .product(testProduct)
+        .quantity(2)
+        .unitPrice(testProduct.getPrice())
+        .totalPrice(testProduct.getPrice().multiply(BigDecimal.valueOf(2)))
+        .build();
+    setIdForTest(testCartItem, 1L);
+
+    // 테스트용 요청 객체 생성
+    cartItemRequest = CartItemRequest.builder()
+        .productId(1L)
+        .quantity(3)
+        .build();
+  }
+
+  // 테스트용 ID 설정을 위한 헬퍼 메서드
+  private void setIdForTest(Object entity, Long id) {
+    try {
+      java.lang.reflect.Field idField = entity.getClass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(entity, id);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set ID for test", e);
+    }
+  }
+
+  @Nested
+  @DisplayName("장바구니 조회 테스트")
+  class GetCartTests {
+
+    @Test
+    @DisplayName("사용자 장바구니 조회 성공")
+    void getCartByUser_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 조회"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+
+      // when
+      CartDto result = cartService.getCartByUser(authorization);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.getCartId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("장바구니가 없을 때 새 장바구니 생성")
+    void getCartByUser_CreateNewCart() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 조회"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.empty());
+      given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+
+      // when
+      CartDto result = cartService.getCartByUser(authorization);
+
+      // then
+      assertThat(result).isNotNull();
+      then(cartRepository).should().save(any(Cart.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 장바구니 조회 실패")
+    void getCartByUser_UserNotFound() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "nonexistent@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 조회"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> cartService.getCartByUser(authorization))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("상품 추가 테스트")
+  class AddCartItemTests {
+
+    @Test
+    @DisplayName("새 상품을 장바구니에 추가 성공")
+    void addCartItem_NewProduct_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 1L)).willReturn(Optional.empty());
+      given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
+      given(cartItemRepository.save(any(CartItem.class))).willReturn(testCartItem);
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+
+      // when
+      CartItemDto result = cartService.addCartItem(authorization, cartItemRequest);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.getProductId()).isEqualTo(1L);
+      assertThat(result.getQuantity()).isEqualTo(3);
+      then(cartItemRepository).should().save(any(CartItem.class));
+      then(cartRepository).should().save(any(Cart.class));
+    }
+
+    @Test
+    @DisplayName("기존 상품의 수량 증가 성공")
+    void addCartItem_ExistingProduct_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItem existingItem = CartItem.builder()
+          .cart(testCart)
+          .product(testProduct)
+          .quantity(2)
+          .unitPrice(testProduct.getPrice())
+          .totalPrice(testProduct.getPrice().multiply(BigDecimal.valueOf(2)))
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 1L)).willReturn(
+          Optional.of(existingItem));
+      given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
+      given(cartItemRepository.save(any(CartItem.class))).willReturn(existingItem);
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+
+      // when
+      CartItemDto result = cartService.addCartItem(authorization, cartItemRequest);
+
+      // then
+      assertThat(result).isNotNull();
+      then(cartItemRepository).should().save(any(CartItem.class));
+      then(cartRepository).should().save(any(Cart.class));
+    }
+
+    @Test
+    @DisplayName("재고 부족으로 상품 추가 실패")
+    void addCartItem_InsufficientStock_Failure() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(2L)
+          .quantity(5) // 재고는 2개만 있음
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 2L)).willReturn(Optional.empty());
+      given(productRepository.findById(2L)).willReturn(Optional.of(outOfStockProduct));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.addCartItem(authorization, request))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CART_INSUFFICIENT_STOCK);
+
+      then(cartItemRepository).should(never()).save(any(CartItem.class));
+    }
+
+    @Test
+    @DisplayName("기존 상품 + 추가 수량으로 재고 부족 실패")
+    void addCartItem_ExistingProductInsufficientStock_Failure() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItem existingItem = CartItem.builder()
+          .cart(testCart)
+          .product(outOfStockProduct)
+          .quantity(1) // 기존 1개
+          .unitPrice(outOfStockProduct.getPrice())
+          .totalPrice(outOfStockProduct.getPrice())
+          .build();
+
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(2L)
+          .quantity(2) // 추가 2개 (총 3개가 되어 재고 2개 초과)
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 2L)).willReturn(
+          Optional.of(existingItem));
+      given(productRepository.findById(2L)).willReturn(Optional.of(outOfStockProduct));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.addCartItem(authorization, request))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CART_INSUFFICIENT_STOCK);
+    }
+
+    @Test
+    @DisplayName("판매 중지된 상품 추가 실패")
+    void addCartItem_InactiveProduct_Failure() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(3L)
+          .quantity(1)
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 3L)).willReturn(Optional.empty());
+      given(productRepository.findById(3L)).willReturn(Optional.of(inactiveProduct));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.addCartItem(authorization, request))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CART_PRODUCT_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 추가 실패")
+    void addCartItem_ProductNotFound_Failure() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(999L)
+          .quantity(1)
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 999L)).willReturn(Optional.empty());
+      given(productRepository.findById(999L)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> cartService.addCartItem(authorization, request))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PRODUCT_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("수량 변경 테스트")
+  class UpdateQuantityTests {
+
+    @Test
+    @DisplayName("장바구니 아이템 수량 변경 성공")
+    void updateCartItemQuantity_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      Integer newQuantity = 5;
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 아이템 수량 변경"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartItemRepository.findById(1L)).willReturn(Optional.of(testCartItem));
+      given(cartRepository.findById(1L)).willReturn(Optional.of(testCart));
+      given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
+      given(cartItemRepository.save(any(CartItem.class))).willReturn(testCartItem);
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+
+      // when
+      CartItemDto result = cartService.updateCartItemQuantity(authorization, 1L, newQuantity);
+
+      // then
+      assertThat(result).isNotNull();
+      then(cartItemRepository).should().save(any(CartItem.class));
+      then(cartRepository).should().save(any(Cart.class));
+    }
+
+    @Test
+    @DisplayName("재고 부족으로 수량 변경 실패")
+    void updateCartItemQuantity_InsufficientStock_Failure() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      Integer newQuantity = 15; // 재고는 10개
+      CartItem cartItemWithOutOfStockProduct = CartItem.builder()
+          .cart(testCart)
+          .product(testProduct)
+          .quantity(2)
+          .unitPrice(testProduct.getPrice())
+          .totalPrice(testProduct.getPrice().multiply(BigDecimal.valueOf(2)))
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 아이템 수량 변경"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartItemRepository.findById(1L)).willReturn(Optional.of(cartItemWithOutOfStockProduct));
+      given(cartRepository.findById(1L)).willReturn(Optional.of(testCart));
+      given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.updateCartItemQuantity(authorization, 1L, newQuantity))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CART_INSUFFICIENT_STOCK);
+
+      then(cartItemRepository).should(never()).save(any(CartItem.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 장바구니 아이템 수량 변경 실패")
+    void updateCartItemQuantity_CartItemNotFound_Failure() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 아이템 수량 변경"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartItemRepository.findById(999L)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> cartService.updateCartItemQuantity(authorization, 999L, 5))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CART_ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 장바구니 아이템 수량 변경 실패")
+    void updateCartItemQuantity_AccessDenied_Failure() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      User otherUser = User.builder()
+          .email("other@example.com")
+          .build();
+      setIdForTest(otherUser, 2L);
+
+      Cart otherUserCart = Cart.builder()
+          .user(otherUser)
+          .totalItems(0)
+          .totalPrice(BigDecimal.ZERO)
+          .build();
+      setIdForTest(otherUserCart, 2L);
+
+      CartItem otherUserCartItem = CartItem.builder()
+          .cart(otherUserCart)
+          .product(testProduct)
+          .quantity(1)
+          .unitPrice(testProduct.getPrice())
+          .totalPrice(testProduct.getPrice())
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 아이템 수량 변경"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartItemRepository.findById(1L)).willReturn(Optional.of(otherUserCartItem));
+      given(cartRepository.findById(2L)).willReturn(Optional.of(otherUserCart));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.updateCartItemQuantity(authorization, 1L, 5))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CART_ACCESS_DENIED);
+    }
+  }
+
+  @Nested
+  @DisplayName("아이템 제거 테스트")
+  class RemoveCartItemTests {
+
+    @Test
+    @DisplayName("장바구니 아이템 제거 성공")
+    void removeCartItem_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 아이템 제거"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartItemRepository.findById(1L)).willReturn(Optional.of(testCartItem));
+      given(cartRepository.findById(1L)).willReturn(Optional.of(testCart));
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+
+      // when
+      cartService.removeCartItem(authorization, 1L);
+
+      // then
+      then(cartItemRepository).should().delete(testCartItem);
+      then(cartRepository).should().save(any(Cart.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("장바구니 비우기 테스트")
+  class ClearCartTests {
+
+    @Test
+    @DisplayName("장바구니 비우기 성공")
+    void clearCart_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 비우기"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+
+      // when
+      cartService.clearCart(authorization);
+
+      // then
+      then(cartRepository).should().save(any(Cart.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("장바구니 요약 테스트")
+  class GetCartSummaryTests {
+
+    @Test
+    @DisplayName("장바구니 요약 조회 성공")
+    void getCartSummary_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 요약 조회"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+
+      // when
+      CartSummaryResponse result = cartService.getCartSummary(authorization);
+
+      // then
+      assertThat(result).isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("장바구니 유효성 검증 테스트")
+  class ValidateCartTests {
+
+    @Test
+    @DisplayName("장바구니 유효성 검증 성공")
+    void validateCart_Success() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      List<CartItem> cartItems = new ArrayList<>();
+      cartItems.add(testCartItem);
+      testCart = Cart.builder()
+          .user(testUser)
+          .totalItems(2)
+          .totalPrice(new BigDecimal("300000"))
+          .cartItems(cartItems)
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 유효성 검증"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+
+      // when
+      CartDto result = cartService.validateCart(authorization);
+
+      // then
+      assertThat(result).isNotNull();
+      then(cartRepository).should().save(any(Cart.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("재고 없는 상품 테스트")
+  class NullStockTests {
+
+    @Test
+    @DisplayName("재고 정보가 null인 상품 추가 실패")
+    void addCartItem_NullStock_Failure() {
+      // given
+      Product nullStockProduct = Product.builder()
+          .name("재고 정보 없는 상품")
+          .price(new BigDecimal("100000"))
+          .stockQuantity(null) // 재고 정보 없음
+          .productStatus(ProductStatus.ACTIVE)
+          .build();
+      setIdForTest(nullStockProduct, 4L);
+
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(4L)
+          .quantity(1)
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 4L)).willReturn(Optional.empty());
+      given(productRepository.findById(4L)).willReturn(Optional.of(nullStockProduct));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.addCartItem(authorization, request))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PRODUCT_INVALID_STOCK);
+    }
+  }
+
+  @Nested
+  @DisplayName("추가 엣지 케이스 테스트")
+  class AdditionalEdgeCaseTests {
+
+    @Test
+    @DisplayName("수량 0으로 변경 시 예외 발생 확인")
+    void updateCartItemQuantity_ZeroQuantity_ThrowsException() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 아이템 수량 변경"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartItemRepository.findById(1L)).willReturn(Optional.of(testCartItem));
+      given(cartRepository.findById(1L)).willReturn(Optional.of(testCart));
+      given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.updateCartItemQuantity(authorization, 1L, 0))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("수량은 0보다 커야 합니다");
+    }
+
+    @Test
+    @DisplayName("매우 큰 수량으로 상품 추가 시 재고 부족 확인")
+    void addCartItem_VeryLargeQuantity_InsufficientStock() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(1L)
+          .quantity(1000) // 매우 큰 수량
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.of(testCart));
+      given(cartItemRepository.findByCartIdAndProductId(1L, 1L)).willReturn(Optional.empty());
+      given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
+
+      // when & then
+      assertThatThrownBy(() -> cartService.addCartItem(authorization, request))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CART_INSUFFICIENT_STOCK);
+    }
+
+    @Test
+    @DisplayName("활성 장바구니가 없을 때 새 장바구니 생성")
+    void addCartItem_NoActiveCart_CreatesNewCart() {
+      // given
+      String authorization = "Bearer valid-token";
+      String email = "test@example.com";
+      CartItemRequest request = CartItemRequest.builder()
+          .productId(1L)
+          .quantity(2)
+          .build();
+
+      given(tokenProcessor.extractEmailFromBearerToken(authorization, "장바구니 상품 추가"))
+          .willReturn(email);
+      given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+      given(cartRepository.findByUserId(1L)).willReturn(Optional.empty()); // 활성 장바구니 없음
+      given(cartItemRepository.findByCartIdAndProductId(anyLong(), eq(1L))).willReturn(
+          Optional.empty());
+      given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
+      given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+      given(cartRepository.save(any(Cart.class))).willReturn(testCart);
+      given(cartItemRepository.save(any(CartItem.class))).willReturn(testCartItem);
+
+      // when
+      CartItemDto result = cartService.addCartItem(authorization, request);
+
+      // then - 새 장바구니가 생성되고 상품이 추가되어야 함
+      assertThat(result).isNotNull();
+      then(cartRepository).should(times(2)).save(any(Cart.class)); // 장바구니 생성 + 아이템 추가 후 저장
+    }
+  }
+}

--- a/backend/src/test/java/com/oboe/backend/common/BaseIntegrationTest.java
+++ b/backend/src/test/java/com/oboe/backend/common/BaseIntegrationTest.java
@@ -1,0 +1,22 @@
+package com.oboe.backend.common;
+
+import com.oboe.backend.config.TestConfig;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 통합 테스트를 위한 공통 Base 클래스
+ * 모든 통합 테스트는 이 클래스를 상속받아 사용
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@Import(TestConfig.class)
+public abstract class BaseIntegrationTest {
+    // 공통 설정만 포함
+    // 구체적인 테스트는 상속받는 클래스에서 구현
+}

--- a/backend/src/test/java/com/oboe/backend/config/TestConfig.java
+++ b/backend/src/test/java/com/oboe/backend/config/TestConfig.java
@@ -1,0 +1,37 @@
+package com.oboe.backend.config;
+
+import com.oboe.backend.common.service.TokenProcessor;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+public class TestConfig {
+
+    /**
+     * 테스트용 TokenProcessor Mock Bean
+     */
+    @Bean
+    @Primary
+    public TokenProcessor tokenProcessor() {
+        return Mockito.mock(TokenProcessor.class);
+    }
+
+    /**
+     * 테스트용 Security 설정 - 모든 요청 허용
+     */
+    @Bean
+    @Primary
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authz -> authz.anyRequest().permitAll())
+            .build();
+    }
+}

--- a/backend/src/test/resources/META-INF/spring.factories
+++ b/backend/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Test Auto Configuration
+org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration=\
+com.oboe.backend.config.TestConfig


### PR DESCRIPTION
- 장바구니 CRUD API 완전 구현 (추가, 수정, 삭제, 비우기)
- 장바구니 상품 추가/수정 시 재고 수량 검증 로직
- 장바구니 요약 정보 및 유효성 검증 API
- JWT 기반 사용자 인증 지원
- Cart 테스트 코드 작성

API 엔드포인트:
- GET /api/v1/carts - 사용자 장바구니 조회
- POST /api/v1/carts/items - 장바구니에 상품 추가
- PUT /api/v1/carts/items/{id} - 상품 수량 변경
- DELETE /api/v1/carts/items/{id} - 상품 제거
- POST /api/v1/carts/clear - 장바구니 비우기
- GET /api/v1/carts/summary - 장바구니 요약 정보
- POST /api/v1/carts/validate - 장바구니 유효성 검증